### PR TITLE
check if config section exists and add new attributes

### DIFF
--- a/bim2sim/project.py
+++ b/bim2sim/project.py
@@ -46,7 +46,8 @@ def open_config(path):
 def add_config_section(config: configparser.ConfigParser, workflow: Workflow,
                        name: str) -> configparser.ConfigParser:
     """Add a section to config with all attributes and default values."""
-    config.add_section(name)
+    if not name in config._sections:
+        config.add_section(name)
     attributes = [attr for attr in list(workflow.__dict__.keys())
                   if not callable(getattr(workflow, attr)) and not
                   attr.startswith('__')]
@@ -54,7 +55,8 @@ def add_config_section(config: configparser.ConfigParser, workflow: Workflow,
         default_value = getattr(workflow, attr).default
         if isinstance(default_value, LOD):
             default_value = default_value.value
-        config[name][attr] = str(default_value)
+        if not attr in config[name]:
+            config[name][attr] = str(default_value)
     return config
 
 


### PR DESCRIPTION
New config sections for new workflows are only added if this section does not exist yet. Errors raised by duplicate section names are avoided.  Attributes are only added, if they have not been set before. For modifications of default values of existing workflows, only new attributes can be added. Default values from workflows in the bim2sim package cannot be modified in new plugins, but new attributes can be added to existing workflows. To modify existing parameters, a new workflow needs to be setup that can be inherited from the existing workflow.