### PR TITLE
hotfix: update sphinx-autodoc-typehints version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,6 @@ sphinx
 sphinx-rtd-theme
 livereload
 myst-parser
-sphinx-autodoc-typehints
+sphinx-autodoc-typehints<=1.20.1
 anybadge
 sphinxcontrib-mermaid


### PR DESCRIPTION
needed as > 1.20.1 leads to problems