### PR TITLE
Restrict EP export to ThermalZones that have boundaries

### DIFF
--- a/bim2sim/plugins/PluginEnergyPlus/bim2sim_energyplus/task/ep_add_2b_bounds.py
+++ b/bim2sim/plugins/PluginEnergyPlus/bim2sim_energyplus/task/ep_add_2b_bounds.py
@@ -18,7 +18,8 @@ from OCC.Core.gp import gp_Pnt
 from bim2sim.kernel.elements.bps import SpaceBoundary2B, ThermalZone, Door, \
     Window
 from bim2sim.task.base import ITask
-from bim2sim.utilities.common_functions import filter_instances
+from bim2sim.utilities.common_functions import filter_instances, \
+    get_spaces_with_bounds
 from bim2sim.utilities.pyocc_tools import PyOCCTools
 from bim2sim.plugins.PluginEnergyPlus.bim2sim_energyplus.task \
     import EPGeomPreprocessing
@@ -64,7 +65,7 @@ class AddSpaceBoundaries2B(ITask):
         """
         logger.info("Generate space boundaries of type 2B")
         inst_2b = dict()
-        spaces = filter_instances(instances, ThermalZone)
+        spaces = get_spaces_with_bounds(instances)
         for space_obj in spaces:
             # compare surface area of IfcSpace shape with sum of space
             # boundary shapes of this thermal zone.

--- a/bim2sim/plugins/PluginEnergyPlus/bim2sim_energyplus/task/ep_geom_preprocessing.py
+++ b/bim2sim/plugins/PluginEnergyPlus/bim2sim_energyplus/task/ep_geom_preprocessing.py
@@ -30,7 +30,8 @@ from bim2sim.kernel.elements.bps import ExternalSpatialElement, SpaceBoundary, \
 from bim2sim.task.base import ITask
 from bim2sim.task.common.inner_loop_remover import convex_decomposition, \
     is_convex_no_holes, is_convex_slow
-from bim2sim.utilities.common_functions import filter_instances
+from bim2sim.utilities.common_functions import filter_instances, \
+    get_spaces_with_bounds
 from bim2sim.utilities.pyocc_tools import PyOCCTools
 
 logger = logging.getLogger(__name__)
@@ -77,7 +78,7 @@ class EPGeomPreprocessing(ITask):
         """
         logger.info("Creates python representation of relevant ifc types")
         instance_dict = {}
-        spaces = filter_instances(instances, ThermalZone)
+        spaces = get_spaces_with_bounds(instances)
         for space in spaces:
             for bound in space.space_boundaries:
                 if not bound.guid in space_boundaries.keys():
@@ -182,7 +183,7 @@ class EPGeomPreprocessing(ITask):
             instances: dict[guid: element]
         """
         logger.info("Fix surface orientation")
-        spaces = filter_instances(instances, ThermalZone)
+        spaces = get_spaces_with_bounds(instances)
         for space in spaces:
             face_list = []
             for bound in space.space_boundaries:

--- a/bim2sim/plugins/PluginEnergyPlus/bim2sim_energyplus/task/ep_idf_cfd_export.py
+++ b/bim2sim/plugins/PluginEnergyPlus/bim2sim_energyplus/task/ep_idf_cfd_export.py
@@ -15,7 +15,8 @@ from stl import mesh, stl
 
 from bim2sim.kernel.elements.bps import ThermalZone, SpaceBoundary
 from bim2sim.task.base import ITask
-from bim2sim.utilities.common_functions import filter_instances
+from bim2sim.utilities.common_functions import filter_instances, \
+    get_spaces_with_bounds
 from bim2sim.utilities.pyocc_tools import PyOCCTools
 
 logger = logging.getLogger(__name__)
@@ -55,7 +56,7 @@ class ExportIdfForCfd(ITask):
             instances: dict[guid: element]
             stl_name: name of the stl file.
         """
-        spaces = filter_instances(instances, ThermalZone)
+        spaces = get_spaces_with_bounds(instances)
         for space_obj in spaces:
             if not hasattr(space_obj, "b_bound_shape"):
                 continue
@@ -132,7 +133,7 @@ class ExportIdfForCfd(ITask):
             stl_name: name of the stl file.
             base_stl_dir: directory of exported stl files
         """
-        spaces = filter_instances(instances, ThermalZone)
+        spaces = get_spaces_with_bounds(instances)
         for space_obj in spaces:
             space_name = space_obj.guid
             stl_dir = base_stl_dir + space_name + "/"
@@ -179,7 +180,7 @@ class ExportIdfForCfd(ITask):
         """
         stl_dir = str(paths.export) + '/'
         space_bound_df = pd.DataFrame(columns=["space_id", "bound_ids"])
-        spaces = filter_instances(instances, ThermalZone)
+        spaces = get_spaces_with_bounds(instances)
         for space in spaces:
             bound_names = []
             for bound in space.space_boundaries:

--- a/bim2sim/utilities/common_functions.py
+++ b/bim2sim/utilities/common_functions.py
@@ -291,3 +291,19 @@ def all_subclasses(cls, as_names: bool = False):
     if as_names:
         all_cls = [cls.__name__ for cls in all_cls]
     return all_cls
+
+
+def get_spaces_with_bounds(instances: dict):
+    """Get spaces (ThermalZone) that provide space boundaries.
+
+    This function extracts spaces from an instance dictionary and returns
+    those spaces that hold space boundaries.
+
+    Args:
+        instances: dict[guid: element]
+    """
+
+    spaces = filter_instances(instances, 'ThermalZone')
+    spaces_with_bounds = [s for s in spaces if s.space_boundaries]
+
+    return spaces_with_bounds


### PR DESCRIPTION
exclude thermal zones from processing for EnergyPlus if they don't have space boundaries.