### PR TITLE
Add option to reset IFC GlobalIDs after IFC import

### DIFF
--- a/bim2sim/kernel/ifc2python.py
+++ b/bim2sim/kernel/ifc2python.py
@@ -7,6 +7,7 @@ import os
 from collections.abc import Iterable
 from typing import Optional, Union, TYPE_CHECKING, Any
 
+import ifcopenshell
 from ifcopenshell import entity_instance, file, open as ifc_open
 
 from bim2sim.kernel.units import parse_ifc
@@ -30,6 +31,13 @@ def load_ifc(path: str) -> file:
     if not os.path.exists(path):
         raise IOError("Path '%s' does not exist"%(path))
     ifc_file = ifc_open(path)
+    return ifc_file
+
+
+def reset_guids(ifc_file) -> file:
+    all_elements = ifc_file.by_type('IfcRoot')
+    for element in all_elements:
+        element.GlobalId = ifcopenshell.guid.new()
     return ifc_file
 
 

--- a/bim2sim/task/common/common.py
+++ b/bim2sim/task/common/common.py
@@ -59,6 +59,8 @@ class LoadIFC(ITask):
         else:
             raise AssertionError("No ifc found. Check '%s'" % path)
         ifc = ifc2python.load_ifc(os.path.abspath(ifc_path))
+        if workflow.reset_guids:
+            ifc = ifc2python.reset_guids(ifc)
         workflow.ifc_units.update(**self.get_ifcunits(ifc))
 
         # Schema2Python.get_ifc_structure(ifc)

--- a/bim2sim/workflow.py
+++ b/bim2sim/workflow.py
@@ -272,6 +272,19 @@ class Workflow(metaclass=AutoSettingNameMeta):
                     'Choose 0.3m as a default value.',
         for_frontend=True
     )
+    reset_guids = WorkflowSetting(
+        default=False,
+        choices={
+            True: 'Reset GlobalIDs from IFC ',
+            False: 'Keep GlobalIDs from IFC'
+        },
+        description='Reset GlobalIDs from imported IFC if duplicate '
+                    'GlobalIDs occur in the IFC. As EnergyPlus evaluates all'
+                    'GlobalIDs upper case only, this might also be '
+                    'applicable if duplicate non-case-sensitive GlobalIDs '
+                    'occur.',
+        for_frontend=True
+    )
 
 
 class PlantSimulation(Workflow):


### PR DESCRIPTION
reset all GlobalIds within an IFC file after loading the IFC. This option can be set in the workflow setting and defaults to FALSE (by default the GlobalIds aren't resetted).