### PR TITLE
fix decision answers

### DIFF
--- a/bim2sim/plugins/PluginAixLib/test/integration_test/test_hvac.py
+++ b/bim2sim/plugins/PluginAixLib/test/integration_test/test_hvac.py
@@ -52,7 +52,8 @@ class TestIntegrationAixLib(IntegrationBaseAixLib, unittest.TestCase):
             'ParallelPump',
             'ConsumerHeatingDistributorModule',
         ]
-        answers = (None, 'HVAC-PipeFitting', 'HVAC-Distributor', 'HVAC-Valve',
+        answers = (None, 'HVAC-PipeFitting', 'HVAC-Distributor',
+                   'HVAC-ThreeWayValve',
                    # 7 dead ends
                    *(True,)*7,
                    # boiler efficiency, boiler power
@@ -85,7 +86,8 @@ class TestIntegrationAixLib(IntegrationBaseAixLib, unittest.TestCase):
             'ConsumerHeatingDistributorModule',
             'GeneratorOneFluid'
         ]
-        answers = (None, 'HVAC-PipeFitting', 'HVAC-Distributor', 'HVAC-Valve',
+        answers = (None, 'HVAC-PipeFitting', 'HVAC-Distributor',
+                   'HVAC-ThreeWayValve',
                    # 6 dead ends
                    *(True,) * 6,
                    # boiler efficiency, flow temp, power, return temp

--- a/bim2sim/plugins/PluginHKESim/test/test_hvac.py
+++ b/bim2sim/plugins/PluginHKESim/test/test_hvac.py
@@ -67,7 +67,8 @@ class TestIntegrationHKESIM(IntegrationBaseHKESIM, unittest.TestCase):
             'ConsumerHeatingDistributorModule',
         ]
         default_logging_setup()
-        answers = (None, 'HVAC-PipeFitting', 'HVAC-Distributor', 'HVAC-Valve',
+        answers = (None, 'HVAC-PipeFitting', 'HVAC-Distributor',
+                   'HVAC-ThreeWayValve',
                    # 7 dead ends
                    *(True,) * 7, 0.75, 50, 150, 70, *(1, 500,) * 7)
         handler = DebugDecisionHandler(answers)


### PR DESCRIPTION
Currently, the threewayvalves are identified by decision as normal valves. This doesn't lead to errors but gives a warning in the log because the expected_hvac_ports are not valid