### PR TITLE
170 integrate common tasks for validation

### DIFF
--- a/bim2sim/plugins/PluginEnergyPlus/bim2sim_energyplus/__init__.py
+++ b/bim2sim/plugins/PluginEnergyPlus/bim2sim_energyplus/__init__.py
@@ -28,7 +28,6 @@ class PluginEnergyPlus(Plugin):
         bps.EnrichMaterial,  # LOD.full
         bps.DisaggregationCreation,
         bps.BindThermalZones,
-        ep_tasks.IfcValidation, #todo: add additional checks to CheckIfcBPS
         ep_tasks.EPGeomPreprocessing,
         ep_tasks.AddSpaceBoundaries2B,
         ep_tasks.WeatherEnergyPlus,

--- a/bim2sim/task/bps/check_ifc.py
+++ b/bim2sim/task/bps/check_ifc.py
@@ -1,3 +1,5 @@
+from ifcopenshell import file
+
 from bim2sim.kernel.elements import bps
 from bim2sim.kernel.ifc2python import get_layers_ifc
 from bim2sim.task.common.common import CheckIfc
@@ -13,6 +15,9 @@ class CheckIfcBPS(CheckIfc):
         super().__init__()
         self.sub_inst_cls = 'IfcRelSpaceBoundary'
         self.plugin = bps
+
+    def check_critical_errors(self, ifc: file):
+        pass
 
     def validate_sub_inst(self, bound) -> list:
         """
@@ -250,7 +255,7 @@ class CheckIfcBPS(CheckIfc):
             False: if check fails
         """
         if bound.RelatedBuildingElement is not None:
-            return bound.RelatedBuildingElement.is_a('IfcBuildingElement')
+            return bound.RelatedBuildingElement.is_a('IfcElement')
 
     @staticmethod
     def _check_conn_geom(bound):
@@ -265,7 +270,7 @@ class CheckIfcBPS(CheckIfc):
             True: if check succeeds
             False: if check fails
         """
-        return bound.ConnectionGeometry.is_a('IfcConnectionSurfaceGeometry')
+        return bound.ConnectionGeometry.is_a('IfcConnectionGeometry')
 
     @staticmethod
     def _check_phys_virt_bound(bound):
@@ -280,7 +285,7 @@ class CheckIfcBPS(CheckIfc):
             False: if check fails
         """
         return bound.PhysicalOrVirtualBoundary.upper() in \
-            {'PHYSICAL', 'VIRTUAL'}
+            {'PHYSICAL', 'VIRTUAL', 'NOTDEFINED'}
 
     @staticmethod
     def _check_int_ext_bound(bound):
@@ -330,7 +335,9 @@ class CheckIfcBPS(CheckIfc):
             True: if check succeeds
             False: if check fails
         """
-        return bound.ConnectionGeometry.SurfaceOnRelatedElement is None
+        return (bound.ConnectionGeometry.SurfaceOnRelatedElement is None or
+                bound.ConnectionGeometry.SurfaceOnRelatedElement.is_a(
+                    'IfcCurveBoundedPlane'))
 
     @staticmethod
     def _check_basis_surface(bound):
@@ -395,7 +402,7 @@ class CheckIfcBPS(CheckIfc):
             True: if check succeeds
             False: if check fails
         """
-        return (s.is_a('IfcPolyline') for s in
+        return (s.is_a('IfcCompositeCurveSegment') for s in
                 bound.ConnectionGeometry.SurfaceOnRelatingElement.
                 OuterBoundary.Segments)
 

--- a/bim2sim/task/bps/check_ifc.py
+++ b/bim2sim/task/bps/check_ifc.py
@@ -15,9 +15,65 @@ class CheckIfcBPS(CheckIfc):
         super().__init__()
         self.sub_inst_cls = 'IfcRelSpaceBoundary'
         self.plugin = bps
+        self.space_indicator = True
 
-    def check_critical_errors(self, ifc: file):
-        pass
+    def check_critical_errors(self, ifc: file, id_list: list):
+        """
+        Checks for critical errors in the IFC file.
+
+        Args:
+            ifc: ifc file loaded with IfcOpenShell
+            id_list: list of all GUID's in IFC File
+        Raises:
+            TypeError: if a critical error is found
+        """
+        self.check_ifc_version(ifc)
+        self.check_critical_uniqueness(id_list)
+        self.check_sub_inst_exist()
+        self.check_rel_space_exist()
+
+    def check_sub_inst_exist(self):
+        """
+        Checks for the existence of IfcRelSpaceBoundaries.
+
+        Only files containing instances of type 'IfcRelSpaceBoundary' are
+        valid for bim2sim.
+
+        Raises:
+            TypeError: if loaded file does not contain IfcRelSpaceBoundaries
+        """
+        if len(self.sub_inst) == 0:
+            raise TypeError(
+                f"Loaded IFC file does not contain instances of type "
+                f"'IfcRelSpaceBoundary' but only files containing "
+                f"IfcRelSpaceBoundaries can be validated. Please ask the "
+                f"creator of the model to provide a valid IFC4 file.")
+
+    def check_rel_space_exist(self):
+        """
+        Checks for the existence of RelatedSpace attribute of
+        IfcRelSpaceBoundaries.
+
+        Only IfcRelSpaceBoundaries with an IfcSpace or
+        IfcExternalSpatialElement are valid for bim2sim.
+
+        Raises:
+            TypeError: if loaded file only contain IfcRelSpaceBoundaries
+            without a valid RelatedSpace.
+        """
+        indicator = False
+        for inst in self.sub_inst:
+            if inst.RelatingSpace is not None:
+                indicator = True
+                print('first rel sp')
+                break
+        if not indicator:
+            raise TypeError(
+                f"Loaded IFC file does only contain IfcRelSpaceBoundaries "
+                f"that do not have an IfcSpace or IfcExternalSpatialElement "
+                f"as RelatedSpace but those are necessary for further "
+                f"calculations. Please ask the creator of the model to provide"
+                f" a valid IFC4 file.")
 
     def validate_sub_inst(self, bound) -> list:
         """

--- a/bim2sim/task/bps/check_ifc.py
+++ b/bim2sim/task/bps/check_ifc.py
@@ -65,7 +65,6 @@ class CheckIfcBPS(CheckIfc):
         for inst in self.sub_inst:
             if inst.RelatingSpace is not None:
                 indicator = True
-                print('first rel sp')
                 break
         if not indicator:
             raise TypeError(

--- a/bim2sim/task/common/common.py
+++ b/bim2sim/task/common/common.py
@@ -946,9 +946,8 @@ class CheckIfc(ITask):
         """
         if len(id_list) > len(set(id_list)):
             raise TypeError(
-                f"Loaded IFC file does not contain instances of type "
-                f"'IfcRelSpaceBoundary' but only files containing "
-                f"IfcRelSpaceBoundaries can be validated. Please ask "
+                f"The GUIDs of the loaded IFC file are not uniquely defined"
+                f" but files containing unique GUIDs can be used. Please ask "
                 f"the creator of the model to provide a valid IFC4 "
                 f"file.")
         ids_upper = list(map(lambda x: x.upper(), id_list))

--- a/bim2sim/task/common/common.py
+++ b/bim2sim/task/common/common.py
@@ -2,6 +2,7 @@ import inspect
 import json
 import logging
 import os
+import warnings
 from typing import Tuple, List, Any, Type, Set, Dict, Generator
 
 from ifcopenshell.file import file
@@ -566,12 +567,12 @@ class CheckIfc(ITask):
             error_summary_sub_inst: summary of errors related to sub_instances
             error_summary_inst: summary of errors related to instances
         """
-        self.check_ifc_version(ifc)
         self.ps_summary = self._get_class_property_sets(self.plugin)
         self.ifc_units = workflow.ifc_units
         self.sub_inst = ifc.by_type(self.sub_inst_cls)
         self.instances = self.get_relevant_instances(ifc)
         self.id_list = [e.GlobalId for e in ifc.by_type("IfcRoot")]
+        self.check_critical_errors(ifc, self.id_list)
         self.error_summary_sub_inst = self.check_inst(
             self.validate_sub_inst, self.sub_inst)
         self.error_summary_inst = self.check_inst(
@@ -590,6 +591,19 @@ class CheckIfc(ITask):
         self._write_errors_to_json(self.plugin)
         self._write_errors_to_html_table(self.plugin)
         return [self.error_summary_sub_inst, self.error_summary_inst],
+
+    def check_critical_errors(self, ifc: file, id_list: list):
+        """
+        Checks for critical errors in the IFC file.
+
+        Args:
+            ifc: ifc file loaded with IfcOpenShell
+            id_list: list of all GUID's in IFC File
+        Raises:
+            TypeError: if a critical error is found
+        """
+        self.check_ifc_version(ifc)
+        self.check_critical_uniqueness(id_list)
 
     @staticmethod
     def check_ifc_version(ifc: file):
@@ -787,7 +801,6 @@ class CheckIfc(ITask):
         Args:
             inst: IFC instance
             id_list: list of all GUID's in IFC File
-
         Returns:
             True: if check succeeds
             False: if check fails
@@ -799,6 +812,32 @@ class CheckIfc(ITask):
         if inst.is_a() in blacklist:
             return True
         return id_list.count(inst.GlobalId) == 1
+
+    @staticmethod
+    def check_critical_uniqueness(id_list):
+        """
+        Checks if all GlobalIds are unique.
+
+        Only files containing unique GUIDs are valid for bim2sim.
+
+        Args:
+            id_list: list of all GUID's in IFC File
+        Raises:
+            TypeError: if loaded file does not have unique GUIDs
+            Warning: if uppercase GUIDs are equal
+        """
+        if len(id_list) > len(set(id_list)):
+            raise TypeError(
+                f"Loaded IFC file does not contain instances of type "
+                f"'IfcRelSpaceBoundary' but only files containing "
+                f"IfcRelSpaceBoundaries can be validated. Please ask "
+                f"the creator of the model to provide a valid IFC4 "
+                f"file.")
+        ids_upper = list(map(lambda x: x.upper(), id_list))
+        if len(ids_upper) > len(set(ids_upper)):
+            warnings.warn(
+                "Uppercase GUIDs are not uniquely defined. A restart using the"
+                "option of generating new GUIDs should be considered.")
 
     def _check_inst_properties(self, inst):
         """


### PR DESCRIPTION
The ifc-validation checks have been updated according to IFC4 such that ep_tasks.IfcValidation can be replaced.

To check the file for critical errors, the function check_critical_errors has been introduced which always uses the previously implemented version check as well as a GUID uniqueness check. While a casesensitive uniqueness check raises a TypeError, an uppercase uniqueness check only raises a UserWarning. In the CheckIfcBPS class the critical error function additionally checks on the existence of IfcRelSpaceBoundaries and their RelatingSpace attributes.