### PR TITLE
490 add unit conversion for space boundaries

### DIFF
--- a/bim2sim/elements/bps_elements.py
+++ b/bim2sim/elements/bps_elements.py
@@ -856,7 +856,8 @@ class SpaceBoundary(RelationBased):
 
         # check if the space boundary shapes need a unit conversion (i.e.,
         # an additional transformation to the correct size and position)
-        conv_required = self.ifc_units.get('IfcLengthMeasure') != ureg.meter
+        length_unit = self.ifc_units.get('IfcLengthMeasure')
+        conv_required = length_unit != ureg.meter
 
         try:
             sore = self.ifc.ConnectionGeometry.SurfaceOnRelatingElement
@@ -913,7 +914,7 @@ class SpaceBoundary(RelationBased):
 
         if conv_required:
             # scale newly created shape of space boundary to correct size
-            conv_factor = (1 * self.ifc_units.get('IfcLengthMeasure')).to(
+            conv_factor = (1 * length_unit).to(
                 ureg.metre).m
             shape = PyOCCTools.scale_shape(shape, conv_factor, gp_Pnt(0, 0, 0))
 
@@ -924,8 +925,7 @@ class SpaceBoundary(RelationBased):
             # position if a unit conversion is required.
             # todo: check if x-, y-coord of "vec" also need to be transformed.
             if conv_required:
-                z_coord = lp[2][3] * self.ifc_units.get(
-                    'IfcLengthMeasure')
+                z_coord = lp[2][3] * length_unit
                 lp[2][3] = z_coord.to(ureg.meter).m
             mat = gp_Mat(lp[0][0], lp[0][1], lp[0][2], lp[1][0], lp[1][1],
                          lp[1][2], lp[2][0], lp[2][1], lp[2][2])

--- a/bim2sim/utilities/pyocc_tools.py
+++ b/bim2sim/utilities/pyocc_tools.py
@@ -144,15 +144,38 @@ class PyOCCTools:
         return prop.CentreOfMass()
 
     @staticmethod
-    def scale_face(face: TopoDS_Face, factor: float) -> TopoDS_Shape:
+    def scale_face(face: TopoDS_Face, factor: float,
+                   predefined_center: gp_Pnt = None) -> TopoDS_Shape:
         """
         Scales the given face by the given factor, using the center of mass of
-        the face as origin of the transformation.
+        the face as origin of the transformation. If another center than the
+        center of mass should be used for the origin of the transformation,
+        set the predefined_center.
         """
-        center = PyOCCTools.get_center_of_face(face)
+        if not predefined_center:
+            center = PyOCCTools.get_center_of_face(face)
+        else:
+            center = predefined_center
         trsf = gp_Trsf()
         trsf.SetScale(center, factor)
         return BRepBuilderAPI_Transform(face, trsf).Shape()
+
+    @staticmethod
+    def scale_shape(shape: TopoDS_Shape, factor: float,
+                    predefined_center: gp_Pnt = None) -> TopoDS_Shape:
+        """
+        Scales the given shape by the given factor, using the center of mass of
+        the shape as origin of the transformation. If another center than the
+        center of mass should be used for the origin of the transformation,
+        set the predefined_center.
+        """
+        if not predefined_center:
+            center = PyOCCTools.get_center_of_volume(shape)
+        else:
+            center = predefined_center
+        trsf = gp_Trsf()
+        trsf.SetScale(center, factor)
+        return BRepBuilderAPI_Transform(shape, trsf).Shape()
 
     @staticmethod
     def scale_edge(edge: TopoDS_Edge, factor: float) -> TopoDS_Shape:


### PR DESCRIPTION
Fix unit conversion in space boundary geometry creation, if input IFC file uses 'Milimeter' as IfcLenghtUnit instead of 'Meter'. 

Background: 
Space boundaries (SB) in IFC are no IfcProducts, such that the SB geometry cannot be created the "common way" using ifcopenshell. We (A) create the SB geometry based on their connection geometry and (B) 'manually' transform it to the correct position of the relating space. 

In part (A), the IFC units have not been considered for now, such that a length in millimeters was treated to be in meters, resulting in incorrect SB areas in the resulting idf. 

I implemented an approach to rescale the space boundaries for cases where the length unit is not meters. 