### PR TITLE
Update docs ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,8 @@ stages:
 #  - visualize
 
 variables:
-  PYTHON_VERSION: "${CI_REGISTRY}/environment:development"
+  PYTHON_VERSION: "registry.git.rwth-aachen.de/ebc/ebc_all/github_ci/bim2sim/environment:development"
+#  PYTHON_VERSION: "${CI_REGISTRY}/environment:development"
   GIT_SUBMODULE_STRATEGY: recursive
   GH_REPO_URL: "git@github.com:BIM2SIM/bim2sim.git"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,7 +21,8 @@ variables:
   # TODO variable inside variable seems not be working on our gitlab instance,
   # see post below, therefore use hardcoded image here for sphinx job
   # https://stackoverflow.com/questions/67005507/variable-inside-variable-gitlab-ci
-  PYTHON_VERSION: "${CI_REGISTRY}/environment:development"
+  PYTHON_VERSION: "registry.git.rwth-aachen.de/ebc/ebc_all/github_ci/bim2sim/environment:development"
+#  PYTHON_VERSION: "${CI_REGISTRY}/environment:development"
   GIT_SUBMODULE_STRATEGY: recursive
   GH_REPO_URL: "git@github.com:BIM2SIM/bim2sim.git"
   GH_PAGES_URL: "https://bim2sim.github.io/${CI_PROJECT_NAME}/"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ variables:
 #  PYTHON_VERSION: "${CI_REGISTRY}/environment:development"
   GIT_SUBMODULE_STRATEGY: recursive
   GH_REPO_URL: "git@github.com:BIM2SIM/bim2sim.git"
+  GH_PAGES_URL: "https://bim2sim.github.io/${CI_PROJECT_NAME}/"
 
 include:
   - project: 'EBC/EBC_all/gitlab_ci/templates'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,14 +17,16 @@ stages:
   - deploy
   - visualize
 
+variables:
+  PYTHON_VERSION: "$CI_REGISTRY/environment:development"
+  GIT_SUBMODULE_STRATEGY: recursive
+
 include:
   - project: 'EBC/EBC_all/gitlab_ci/templates'
     file: 'python/doc/sphinxdoc.gitlab-ci.yml'
   - project: 'EBC/EBC_all/gitlab_ci/templates'
     file: 'pages/gh-pages.gitlab-ci.yml'
 
-variables:
-  GIT_SUBMODULE_STRATEGY: recursive
 
 #build_env:master:
 # image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,9 +21,7 @@ variables:
   # TODO variable inside variable seems not be working on our gitlab instance,
   # see post below, therefore use hardcoded image here for sphinx job
   # https://stackoverflow.com/questions/67005507/variable-inside-variable-gitlab-ci
-#  PYTHON_VERSION: "registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:python_3.9"
-  PYTHON_VERSION: "registry.git.rwth-aachen.de/ebc/ebc_all/github_ci/bim2sim/environment:development"
-#  PYTHON_VERSION: "${CI_REGISTRY}/environment:development"
+  PYTHON_VERSION: "${CI_REGISTRY}/environment:development"
   GIT_SUBMODULE_STRATEGY: recursive
   GH_REPO_URL: "git@github.com:BIM2SIM/bim2sim.git"
   GH_PAGES_URL: "https://bim2sim.github.io/${CI_PROJECT_NAME}/"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,7 @@ stages:
 variables:
   PYTHON_VERSION: "${CI_REGISTRY}/environment:development"
   GIT_SUBMODULE_STRATEGY: recursive
+  GH_REPO_URL: "git@github.com:BIM2SIM/bim2sim.git"
 
 include:
   - project: 'EBC/EBC_all/gitlab_ci/templates'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,489 +26,489 @@ include:
 variables:
   GIT_SUBMODULE_STRATEGY: recursive
 
-build_env:master:
- image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
- stage: build-env
- services:
-   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-     command: ["--mtu=1440"]
- before_script:
-   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
- script:
-   - docker build -t $CI_REGISTRY/environment:master -f envBase.Dockerfile . 
-   - docker push $CI_REGISTRY/environment:master
- only:
-   refs:
-      - master
-   changes:
-      - envBase.Dockerfile
-      - requirements.txt
-
-build_env:development:
- image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
- stage: build-env
- services:
-   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-     command: ["--mtu=1440"]
- before_script:
-   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
- script:
-   - docker build -t $CI_REGISTRY/environment:development -f envBase.Dockerfile .
-   - docker push $CI_REGISTRY/environment:development
- only:
-   refs:
-      - development
-   changes:
-      - envBase.Dockerfile
-      - requirements.txt
-      - .gitlab-ci.yml
-
-build_env:dymola:
- image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
- stage: build-env
- services:
-   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-     command: ["--mtu=1440"]
- before_script:
-   - docker login -u $CI_DEPLOY_TOKEN_USERNAME_DYMOLA -p $CI_DEPLOY_TOKEN_PASSWORD_DYMOLA $CI_REGISTRY_LOGIN_DYMOLA   # login dymola docker reg
- script:
-   - docker build -t $CI_REGISTRY/environment:dymola -f envBaseDymola.Dockerfile .
-   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN  # login bim2sim reg
-   - docker push $CI_REGISTRY/environment:dymola
- only:
-   refs:
-      - development
-   changes:
-      - envBaseDymola.Dockerfile
-      - requirements.txt
-      - .gitlab-ci.yml
-
-
-build_env:energyplus:
-  image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
-  stage: build-env-plugins
-  services:
-   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-     command: ["--mtu=1440"]
-  before_script:
-    - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
-  script:
-    - docker build -t $CI_REGISTRY/environment:energyplus -f bim2sim/plugins/PluginEnergyPlus/envEP.Dockerfile .
-    - docker push $CI_REGISTRY/environment:energyplus
-  only:
-    refs:
-       - development
-    changes:
-       - envBase.Dockerfile
-       - bim2sim/plugins/PluginEnergyPlus/envEP.Dockerfile
-       - bim2sim/plugins/PluginEnergyPlus/requirements.txt
-       - requirements.txt
-       - .gitlab-ci.yml
-
-build_env:cfd:
- image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
- stage: build-env-plugins
- services:
-   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-     command: ["--mtu=1440"]
- before_script:
-   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
- script:
-   - docker build -t $CI_REGISTRY/environment:cfd -f bim2sim/plugins/PluginCFD/envCFD.Dockerfile .
-   - docker push $CI_REGISTRY/environment:cfd
- timeout: 6 hours
- only:
-   refs:
-      - development
-   changes:
-      - envBase.Dockerfile
-      - bim2sim/plugins/PluginCFD/envCFD.Dockerfile
-      - requirements.txt
-      - .gitlab-ci.yml
-
-build_env:teaser:
- image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
- stage: build-env-plugins
- services:
-   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-     command: ["--mtu=1440"]
- before_script:
-   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
- script:
-   - docker build -t $CI_REGISTRY/environment:teaser -f bim2sim/plugins/PluginTEASER/envTEASER.Dockerfile .
-   - docker push $CI_REGISTRY/environment:teaser
- only:
-   refs:
-     - development
-   changes:
-     - envBase.Dockerfile
-     - bim2sim/plugins/PluginTEASER/requirements.txt
-     - bim2sim/plugins/PluginTEASER/envTEASER.Dockerfile
-     - requirements.txt
-     - .gitlab-ci.yml
-
-
-build_env:teaser-dymola:
- image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
- stage: build-env-plugins
- services:
-   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-     command: ["--mtu=1440"]
- before_script:
-   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
- script:
-   - docker build -t $CI_REGISTRY/environment:teaser-dymola -f bim2sim/plugins/PluginTEASER/envTEASER-dymola.Dockerfile .
-   - docker push $CI_REGISTRY/environment:teaser-dymola
- only:
-   refs:
-     - development
-   changes:
-     - envBase.Dockerfile
-     - bim2sim/plugins/PluginTEASER/requirements.txt
-     - bim2sim/plugins/PluginTEASER/envTEASER.Dockerfile
-     - requirements.txt
-     - .gitlab-ci.yml
-
-
-build_env:aixlib:
- image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
- stage: build-env-plugins
- services:
-   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-     command: ["--mtu=1440"]
- before_script:
-   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
- script:
-   - docker build -t $CI_REGISTRY/environment:aixlib -f bim2sim/plugins/PluginAixLib/envAixLib.Dockerfile .
-   - docker push $CI_REGISTRY/environment:aixlib
- only:
-   refs:
-     - development
-   changes:
-     - envBase.Dockerfile
-     - bim2sim/plugins/PluginAixLib/requirements.txt
-     - bim2sim/plugins/PluginAixLib/envAixLib.Dockerfile
-     - requirements.txt
-     - .gitlab-ci.yml
-
-build_tool:release:
- image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
- stage: build-tool
- services:
-   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-     command: ["--mtu=1440"]
- before_script:
-   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
- script:
-   - docker build -t $CI_REGISTRY/tool:latest .
-   - docker push $CI_REGISTRY/tool:latest
- only:
-   - master
-
-build_tool:development:
- image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
- stage: build-tool
- services:
-   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-     command: ["--mtu=1440"]
- before_script:
-   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
- script:
-   - docker build -t $CI_REGISTRY/tool:development .
-   - docker push $CI_REGISTRY/tool:development
- only:
-   - development
-
-build_tool:webdevelop:
- image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
- stage: build-tool
- services:
-   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-     command: ["--mtu=1440"]
- before_script:
-   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
- script:
-   - docker build -t $CI_REGISTRY/tool:web_develop -f total.Dockerfile .
-   - docker push $CI_REGISTRY/tool:web_develop
- only:
-   - development
-
-build_tool:cfd:
- image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
- stage: build-tool
- services:
-   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-     command: ["--mtu=1440"]
- before_script:
-   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
- script:
-   - docker build -t $CI_REGISTRY/tool:cfd -f bim2sim/plugins/PluginCFD/cfd.Dockerfile .
-   - docker push $CI_REGISTRY/tool:cfd
- only:
-   changes:
-      - bim2sim/plugins/PluginCFD/*
-
-build_tool:teaser:
- image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
- stage: build-tool
- services:
-   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-     command: ["--mtu=1440"]
- before_script:
-   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
- script:
-   - docker build -t $CI_REGISTRY/tool:teaser -f bim2sim/plugins/PluginTEASER/teaser.Dockerfile .
-   - docker push $CI_REGISTRY/tool:teaser
- only:
-   changes:
-      - bim2sim/plugins/PluginTEASER/*
-
-build_tool:aixlib:
- image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
- stage: build-tool
- services:
-   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-     command: ["--mtu=1440"]
- before_script:
-   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
- script:
-   - docker build -t $CI_REGISTRY/tool:aixlib -f bim2sim/plugins/PluginAixLib/aixlib.Dockerfile .
-   - docker push $CI_REGISTRY/tool:aixlib
- only:
-   changes:
-      - bim2sim/plugins/PluginAixLib/*
-
-test_Base:
-  <<: *test-default
-  image: $CI_REGISTRY/environment:development
-  stage: test
-  services:
-   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-     command: ["--mtu=1440"]
-  before_script:
-    - pip install coverage
-    - pip install coverage-badge
-  script:
-    - mv ./* /bim2sim-coding/
-    - cd /bim2sim-coding
-    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=hydraulic --force_new
-    - coverage run -m unittest discover /bim2sim-coding/test
-    - coverage report -i
-    - mkdir -p $CI_COMMIT_REF_NAME/coverage
-    - coverage html -i
-    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
-    # skip this for now as its only cosmetic and leads to problems
-    # - coverage-badge -o coverage.svg
-    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
-  artifacts:
-    paths:
-    - $CI_COMMIT_REF_NAME/coverage
-
-test_EP:
-  <<: *test-default
-  image: $CI_REGISTRY/environment:energyplus
-  stage: test
-  services:
-   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-     command: ["--mtu=1440"]
-  before_script:
-    - pip install coverage
-    - pip install coverage-badge
-  script:
-    - mv ./* /bim2sim-coding/
-    - cd /bim2sim-coding
-    - cat /bim2sim-coding/bim2sim/plugins/PluginEnergyPlus/data/Minimal.idf
-    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new
-    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginEnergyPlus/test/integration
-    - coverage report -i
-    - mkdir -p $CI_COMMIT_REF_NAME/coverage
-    - coverage html -i
-    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
-    # skip this for now as its only cosmetic and leads to problems
-    # - coverage-badge -o coverage.svg
-    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
-  artifacts:
-    paths:
-    - $CI_COMMIT_REF_NAME/coverage
-
-test_EP_regression:
-  <<: *test-default
-  image: $CI_REGISTRY/environment:energyplus
-  stage: test
-  before_script:
-    - pip install coverage
-    - pip install coverage-badge
-  script:
-    - mv ./* /bim2sim-coding/
-    - cd /bim2sim-coding
-    - cat /bim2sim-coding/bim2sim/plugins/PluginEnergyPlus/data/Minimal.idf
-    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new --with_regression
-    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginEnergyPlus/test/regression
-    - coverage report -i
-    - mkdir -p $CI_COMMIT_REF_NAME/coverage
-    - coverage html -i
-    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
-    # skip this for now as its only cosmetic and leads to problems
-    # - coverage-badge -o coverage.svg
-    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
-  artifacts:
-    paths:
-    - $CI_COMMIT_REF_NAME/coverage
-
-test_TEASER:
-  <<: *test-default
-  image: $CI_REGISTRY/environment:teaser
-  stage: test
-  services:
-   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-     command: ["--mtu=1440"]
-  before_script:
-    - pip install coverage
-    - pip install coverage-badge
-  script:
-    - mv ./* /bim2sim-coding/
-    - cd /bim2sim-coding
-    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new
-    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginTEASER/test/integration
-    - coverage report -i
-    - mkdir -p $CI_COMMIT_REF_NAME/coverage
-    - coverage html -i
-    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
-    # skip this for now as its only cosmetic and leads to problems
-    # - coverage-badge -o coverage.svg
-    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
-  artifacts:
-    paths:
-    - $CI_COMMIT_REF_NAME/coverage
-
-test_TEASER_regression:
-  <<: *test-default
-  image: $CI_REGISTRY/environment:teaser-dymola
-  stage: test
-  before_script:
-    - pip install coverage
-    - pip install coverage-badge
-  script:
-    - mv ./* /bim2sim-coding/
-    - cd /bim2sim-coding
-    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new --with_regression
-    - xvfb-run -n 77 coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginTEASER/test/regression
-    - coverage report -i
-    - mkdir -p $CI_COMMIT_REF_NAME/coverage
-    - coverage html -i
-    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
-    # skip this for now as its only cosmetic and leads to problems
-    # - coverage-badge -o coverage.svg
-    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
-  artifacts:
-    paths:
-    - $CI_COMMIT_REF_NAME/coverage
-
-test_CFD:
-  <<: *test-default
-  image: $CI_REGISTRY/environment:cfd
-  stage: test
-  services:
-   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-     command: ["--mtu=1440"]
-  before_script:
-    - pip install coverage
-    - pip install coverage-badge
-  script:
-    - mv ./* /bim2sim-coding/
-    - cd /bim2sim-coding
-    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new
-    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginCFD/test/integration
-    - coverage report -i
-    - mkdir -p $CI_COMMIT_REF_NAME/coverage
-    - coverage html -i
-    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
-    # skip this for now as its only cosmetic and leads to problems
-    # - coverage-badge -o coverage.svg
-    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
-  artifacts:
-    paths:
-    - $CI_COMMIT_REF_NAME/coverage
-
-test_AixLib:
-  <<: *test-default
-  image: $CI_REGISTRY/environment:aixlib
-  stage: test
-  services:
-   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-     command: ["--mtu=1440"]
-  before_script:
-    - pip install coverage
-    - pip install coverage-badge
-  script:
-    - mv ./* /bim2sim-coding/
-    - cd /bim2sim-coding
-    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=hydraulic --force_new
-    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginAixLib/test/integration
-    - coverage report -i
-    - mkdir -p $CI_COMMIT_REF_NAME/coverage
-    - coverage html -i
-    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
-    # skip this for now as its only cosmetic and leads to problems
-    # - coverage-badge -o coverage.svg
-    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
-  artifacts:
-    paths:
-    - $CI_COMMIT_REF_NAME/coverage
-
-test_LCA:
-  <<: *test-default
-  image: $CI_REGISTRY/environment:development
-  stage: test
-  before_script:
-    - pip install coverage
-    - pip install coverage-badge
-  script:
-    - mv ./* /bim2sim-coding/
-    - cd /bim2sim-coding
-    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new
-    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginLCA/test/integration
-    - coverage report -i
-    - mkdir -p $CI_COMMIT_REF_NAME/coverage
-    - coverage html -i
-    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
-    # skip this for now as its only cosmetic and leads to problems
-    # - coverage-badge -o coverage.svg
-    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
-  artifacts:
-    paths:
-    - $CI_COMMIT_REF_NAME/coverage
-
-
-pylint:
- <<: *test-default
- stage: code_quality
- image: python:3.6
- services:
-   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-     command: ["--mtu=1440"]
- before_script:
-   - pip install pylint pylint-json2html anybadge --quiet
- script:
-    - mkdir -p $CI_COMMIT_REF_NAME/pylint
-    # Determine code to check: in a user-defined directory, or module with the project name, or all python files
-    # (In case of using the project name, make project-name pep8 lowercase to be detected by pylint)
-    - if [ ! -z "$PYLINT_INPUT" ]; 
-      then echo "Using user-defined source dir"; 
-      elif [ -d "$CI_PROJECT_NAME" ]; 
-      then echo "Using repo name as module name" && PYLINT_INPUT=`echo "$CI_PROJECT_NAME" | tr '[:upper:]' '[:lower:]'`; 
-      else echo "Checking all python files" && PYLINT_INPUT="**/*.py"; 
-      fi
-    # Run pylint on the python-project
-    - pylint --output-format=text $PYLINT_INPUT --exit-zero | tee $CI_COMMIT_REF_NAME/pylint/pylint.txt
-    - score=$(sed -n 's/^Your code has been rated at \([-0-9.]*\)\/.*/\1/p' $CI_COMMIT_REF_NAME/pylint/pylint.txt)
-    - anybadge --value=$score --file=$CI_COMMIT_REF_NAME/pylint/pylint.svg pylint
-    - pylint --output-format=jsonextended --load-plugins=pylint_json2html --exit-zero $PYLINT_INPUT | tee $CI_COMMIT_REF_NAME/pylint/pylint.json
-    - pylint-json2html -f jsonextended -o $CI_COMMIT_REF_NAME/pylint/pylint.html < $CI_COMMIT_REF_NAME/pylint/pylint.json
- artifacts:
-   paths:
-   - $CI_COMMIT_REF_NAME/pylint
-   expire_in: 2 hrs
+#build_env:master:
+# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+# stage: build-env
+# services:
+#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+#     command: ["--mtu=1440"]
+# before_script:
+#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+# script:
+#   - docker build -t $CI_REGISTRY/environment:master -f envBase.Dockerfile .
+#   - docker push $CI_REGISTRY/environment:master
+# only:
+#   refs:
+#      - master
+#   changes:
+#      - envBase.Dockerfile
+#      - requirements.txt
+#
+#build_env:development:
+# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+# stage: build-env
+# services:
+#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+#     command: ["--mtu=1440"]
+# before_script:
+#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+# script:
+#   - docker build -t $CI_REGISTRY/environment:development -f envBase.Dockerfile .
+#   - docker push $CI_REGISTRY/environment:development
+# only:
+#   refs:
+#      - development
+#   changes:
+#      - envBase.Dockerfile
+#      - requirements.txt
+#      - .gitlab-ci.yml
+#
+#build_env:dymola:
+# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+# stage: build-env
+# services:
+#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+#     command: ["--mtu=1440"]
+# before_script:
+#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME_DYMOLA -p $CI_DEPLOY_TOKEN_PASSWORD_DYMOLA $CI_REGISTRY_LOGIN_DYMOLA   # login dymola docker reg
+# script:
+#   - docker build -t $CI_REGISTRY/environment:dymola -f envBaseDymola.Dockerfile .
+#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN  # login bim2sim reg
+#   - docker push $CI_REGISTRY/environment:dymola
+# only:
+#   refs:
+#      - development
+#   changes:
+#      - envBaseDymola.Dockerfile
+#      - requirements.txt
+#      - .gitlab-ci.yml
+#
+#
+#build_env:energyplus:
+#  image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+#  stage: build-env-plugins
+#  services:
+#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+#     command: ["--mtu=1440"]
+#  before_script:
+#    - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+#  script:
+#    - docker build -t $CI_REGISTRY/environment:energyplus -f bim2sim/plugins/PluginEnergyPlus/envEP.Dockerfile .
+#    - docker push $CI_REGISTRY/environment:energyplus
+#  only:
+#    refs:
+#       - development
+#    changes:
+#       - envBase.Dockerfile
+#       - bim2sim/plugins/PluginEnergyPlus/envEP.Dockerfile
+#       - bim2sim/plugins/PluginEnergyPlus/requirements.txt
+#       - requirements.txt
+#       - .gitlab-ci.yml
+#
+#build_env:cfd:
+# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+# stage: build-env-plugins
+# services:
+#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+#     command: ["--mtu=1440"]
+# before_script:
+#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+# script:
+#   - docker build -t $CI_REGISTRY/environment:cfd -f bim2sim/plugins/PluginCFD/envCFD.Dockerfile .
+#   - docker push $CI_REGISTRY/environment:cfd
+# timeout: 6 hours
+# only:
+#   refs:
+#      - development
+#   changes:
+#      - envBase.Dockerfile
+#      - bim2sim/plugins/PluginCFD/envCFD.Dockerfile
+#      - requirements.txt
+#      - .gitlab-ci.yml
+#
+#build_env:teaser:
+# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+# stage: build-env-plugins
+# services:
+#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+#     command: ["--mtu=1440"]
+# before_script:
+#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+# script:
+#   - docker build -t $CI_REGISTRY/environment:teaser -f bim2sim/plugins/PluginTEASER/envTEASER.Dockerfile .
+#   - docker push $CI_REGISTRY/environment:teaser
+# only:
+#   refs:
+#     - development
+#   changes:
+#     - envBase.Dockerfile
+#     - bim2sim/plugins/PluginTEASER/requirements.txt
+#     - bim2sim/plugins/PluginTEASER/envTEASER.Dockerfile
+#     - requirements.txt
+#     - .gitlab-ci.yml
+#
+#
+#build_env:teaser-dymola:
+# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+# stage: build-env-plugins
+# services:
+#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+#     command: ["--mtu=1440"]
+# before_script:
+#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+# script:
+#   - docker build -t $CI_REGISTRY/environment:teaser-dymola -f bim2sim/plugins/PluginTEASER/envTEASER-dymola.Dockerfile .
+#   - docker push $CI_REGISTRY/environment:teaser-dymola
+# only:
+#   refs:
+#     - development
+#   changes:
+#     - envBase.Dockerfile
+#     - bim2sim/plugins/PluginTEASER/requirements.txt
+#     - bim2sim/plugins/PluginTEASER/envTEASER.Dockerfile
+#     - requirements.txt
+#     - .gitlab-ci.yml
+#
+#
+#build_env:aixlib:
+# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+# stage: build-env-plugins
+# services:
+#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+#     command: ["--mtu=1440"]
+# before_script:
+#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+# script:
+#   - docker build -t $CI_REGISTRY/environment:aixlib -f bim2sim/plugins/PluginAixLib/envAixLib.Dockerfile .
+#   - docker push $CI_REGISTRY/environment:aixlib
+# only:
+#   refs:
+#     - development
+#   changes:
+#     - envBase.Dockerfile
+#     - bim2sim/plugins/PluginAixLib/requirements.txt
+#     - bim2sim/plugins/PluginAixLib/envAixLib.Dockerfile
+#     - requirements.txt
+#     - .gitlab-ci.yml
+#
+#build_tool:release:
+# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+# stage: build-tool
+# services:
+#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+#     command: ["--mtu=1440"]
+# before_script:
+#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+# script:
+#   - docker build -t $CI_REGISTRY/tool:latest .
+#   - docker push $CI_REGISTRY/tool:latest
+# only:
+#   - master
+#
+#build_tool:development:
+# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+# stage: build-tool
+# services:
+#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+#     command: ["--mtu=1440"]
+# before_script:
+#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+# script:
+#   - docker build -t $CI_REGISTRY/tool:development .
+#   - docker push $CI_REGISTRY/tool:development
+# only:
+#   - development
+#
+#build_tool:webdevelop:
+# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+# stage: build-tool
+# services:
+#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+#     command: ["--mtu=1440"]
+# before_script:
+#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+# script:
+#   - docker build -t $CI_REGISTRY/tool:web_develop -f total.Dockerfile .
+#   - docker push $CI_REGISTRY/tool:web_develop
+# only:
+#   - development
+#
+#build_tool:cfd:
+# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+# stage: build-tool
+# services:
+#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+#     command: ["--mtu=1440"]
+# before_script:
+#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+# script:
+#   - docker build -t $CI_REGISTRY/tool:cfd -f bim2sim/plugins/PluginCFD/cfd.Dockerfile .
+#   - docker push $CI_REGISTRY/tool:cfd
+# only:
+#   changes:
+#      - bim2sim/plugins/PluginCFD/*
+#
+#build_tool:teaser:
+# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+# stage: build-tool
+# services:
+#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+#     command: ["--mtu=1440"]
+# before_script:
+#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+# script:
+#   - docker build -t $CI_REGISTRY/tool:teaser -f bim2sim/plugins/PluginTEASER/teaser.Dockerfile .
+#   - docker push $CI_REGISTRY/tool:teaser
+# only:
+#   changes:
+#      - bim2sim/plugins/PluginTEASER/*
+#
+#build_tool:aixlib:
+# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+# stage: build-tool
+# services:
+#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+#     command: ["--mtu=1440"]
+# before_script:
+#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+# script:
+#   - docker build -t $CI_REGISTRY/tool:aixlib -f bim2sim/plugins/PluginAixLib/aixlib.Dockerfile .
+#   - docker push $CI_REGISTRY/tool:aixlib
+# only:
+#   changes:
+#      - bim2sim/plugins/PluginAixLib/*
+#
+#test_Base:
+#  <<: *test-default
+#  image: $CI_REGISTRY/environment:development
+#  stage: test
+#  services:
+#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+#     command: ["--mtu=1440"]
+#  before_script:
+#    - pip install coverage
+#    - pip install coverage-badge
+#  script:
+#    - mv ./* /bim2sim-coding/
+#    - cd /bim2sim-coding
+#    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=hydraulic --force_new
+#    - coverage run -m unittest discover /bim2sim-coding/test
+#    - coverage report -i
+#    - mkdir -p $CI_COMMIT_REF_NAME/coverage
+#    - coverage html -i
+#    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
+#    # skip this for now as its only cosmetic and leads to problems
+#    # - coverage-badge -o coverage.svg
+#    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
+#  artifacts:
+#    paths:
+#    - $CI_COMMIT_REF_NAME/coverage
+#
+#test_EP:
+#  <<: *test-default
+#  image: $CI_REGISTRY/environment:energyplus
+#  stage: test
+#  services:
+#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+#     command: ["--mtu=1440"]
+#  before_script:
+#    - pip install coverage
+#    - pip install coverage-badge
+#  script:
+#    - mv ./* /bim2sim-coding/
+#    - cd /bim2sim-coding
+#    - cat /bim2sim-coding/bim2sim/plugins/PluginEnergyPlus/data/Minimal.idf
+#    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new
+#    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginEnergyPlus/test/integration
+#    - coverage report -i
+#    - mkdir -p $CI_COMMIT_REF_NAME/coverage
+#    - coverage html -i
+#    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
+#    # skip this for now as its only cosmetic and leads to problems
+#    # - coverage-badge -o coverage.svg
+#    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
+#  artifacts:
+#    paths:
+#    - $CI_COMMIT_REF_NAME/coverage
+#
+#test_EP_regression:
+#  <<: *test-default
+#  image: $CI_REGISTRY/environment:energyplus
+#  stage: test
+#  before_script:
+#    - pip install coverage
+#    - pip install coverage-badge
+#  script:
+#    - mv ./* /bim2sim-coding/
+#    - cd /bim2sim-coding
+#    - cat /bim2sim-coding/bim2sim/plugins/PluginEnergyPlus/data/Minimal.idf
+#    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new --with_regression
+#    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginEnergyPlus/test/regression
+#    - coverage report -i
+#    - mkdir -p $CI_COMMIT_REF_NAME/coverage
+#    - coverage html -i
+#    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
+#    # skip this for now as its only cosmetic and leads to problems
+#    # - coverage-badge -o coverage.svg
+#    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
+#  artifacts:
+#    paths:
+#    - $CI_COMMIT_REF_NAME/coverage
+#
+#test_TEASER:
+#  <<: *test-default
+#  image: $CI_REGISTRY/environment:teaser
+#  stage: test
+#  services:
+#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+#     command: ["--mtu=1440"]
+#  before_script:
+#    - pip install coverage
+#    - pip install coverage-badge
+#  script:
+#    - mv ./* /bim2sim-coding/
+#    - cd /bim2sim-coding
+#    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new
+#    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginTEASER/test/integration
+#    - coverage report -i
+#    - mkdir -p $CI_COMMIT_REF_NAME/coverage
+#    - coverage html -i
+#    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
+#    # skip this for now as its only cosmetic and leads to problems
+#    # - coverage-badge -o coverage.svg
+#    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
+#  artifacts:
+#    paths:
+#    - $CI_COMMIT_REF_NAME/coverage
+#
+#test_TEASER_regression:
+#  <<: *test-default
+#  image: $CI_REGISTRY/environment:teaser-dymola
+#  stage: test
+#  before_script:
+#    - pip install coverage
+#    - pip install coverage-badge
+#  script:
+#    - mv ./* /bim2sim-coding/
+#    - cd /bim2sim-coding
+#    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new --with_regression
+#    - xvfb-run -n 77 coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginTEASER/test/regression
+#    - coverage report -i
+#    - mkdir -p $CI_COMMIT_REF_NAME/coverage
+#    - coverage html -i
+#    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
+#    # skip this for now as its only cosmetic and leads to problems
+#    # - coverage-badge -o coverage.svg
+#    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
+#  artifacts:
+#    paths:
+#    - $CI_COMMIT_REF_NAME/coverage
+#
+#test_CFD:
+#  <<: *test-default
+#  image: $CI_REGISTRY/environment:cfd
+#  stage: test
+#  services:
+#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+#     command: ["--mtu=1440"]
+#  before_script:
+#    - pip install coverage
+#    - pip install coverage-badge
+#  script:
+#    - mv ./* /bim2sim-coding/
+#    - cd /bim2sim-coding
+#    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new
+#    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginCFD/test/integration
+#    - coverage report -i
+#    - mkdir -p $CI_COMMIT_REF_NAME/coverage
+#    - coverage html -i
+#    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
+#    # skip this for now as its only cosmetic and leads to problems
+#    # - coverage-badge -o coverage.svg
+#    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
+#  artifacts:
+#    paths:
+#    - $CI_COMMIT_REF_NAME/coverage
+#
+#test_AixLib:
+#  <<: *test-default
+#  image: $CI_REGISTRY/environment:aixlib
+#  stage: test
+#  services:
+#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+#     command: ["--mtu=1440"]
+#  before_script:
+#    - pip install coverage
+#    - pip install coverage-badge
+#  script:
+#    - mv ./* /bim2sim-coding/
+#    - cd /bim2sim-coding
+#    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=hydraulic --force_new
+#    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginAixLib/test/integration
+#    - coverage report -i
+#    - mkdir -p $CI_COMMIT_REF_NAME/coverage
+#    - coverage html -i
+#    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
+#    # skip this for now as its only cosmetic and leads to problems
+#    # - coverage-badge -o coverage.svg
+#    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
+#  artifacts:
+#    paths:
+#    - $CI_COMMIT_REF_NAME/coverage
+#
+#test_LCA:
+#  <<: *test-default
+#  image: $CI_REGISTRY/environment:development
+#  stage: test
+#  before_script:
+#    - pip install coverage
+#    - pip install coverage-badge
+#  script:
+#    - mv ./* /bim2sim-coding/
+#    - cd /bim2sim-coding
+#    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new
+#    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginLCA/test/integration
+#    - coverage report -i
+#    - mkdir -p $CI_COMMIT_REF_NAME/coverage
+#    - coverage html -i
+#    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
+#    # skip this for now as its only cosmetic and leads to problems
+#    # - coverage-badge -o coverage.svg
+#    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
+#  artifacts:
+#    paths:
+#    - $CI_COMMIT_REF_NAME/coverage
+#
+#
+#pylint:
+# <<: *test-default
+# stage: code_quality
+# image: python:3.6
+# services:
+#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+#     command: ["--mtu=1440"]
+# before_script:
+#   - pip install pylint pylint-json2html anybadge --quiet
+# script:
+#    - mkdir -p $CI_COMMIT_REF_NAME/pylint
+#    # Determine code to check: in a user-defined directory, or module with the project name, or all python files
+#    # (In case of using the project name, make project-name pep8 lowercase to be detected by pylint)
+#    - if [ ! -z "$PYLINT_INPUT" ];
+#      then echo "Using user-defined source dir";
+#      elif [ -d "$CI_PROJECT_NAME" ];
+#      then echo "Using repo name as module name" && PYLINT_INPUT=`echo "$CI_PROJECT_NAME" | tr '[:upper:]' '[:lower:]'`;
+#      else echo "Checking all python files" && PYLINT_INPUT="**/*.py";
+#      fi
+#    # Run pylint on the python-project
+#    - pylint --output-format=text $PYLINT_INPUT --exit-zero | tee $CI_COMMIT_REF_NAME/pylint/pylint.txt
+#    - score=$(sed -n 's/^Your code has been rated at \([-0-9.]*\)\/.*/\1/p' $CI_COMMIT_REF_NAME/pylint/pylint.txt)
+#    - anybadge --value=$score --file=$CI_COMMIT_REF_NAME/pylint/pylint.svg pylint
+#    - pylint --output-format=jsonextended --load-plugins=pylint_json2html --exit-zero $PYLINT_INPUT | tee $CI_COMMIT_REF_NAME/pylint/pylint.json
+#    - pylint-json2html -f jsonextended -o $CI_COMMIT_REF_NAME/pylint/pylint.html < $CI_COMMIT_REF_NAME/pylint/pylint.json
+# artifacts:
+#   paths:
+#   - $CI_COMMIT_REF_NAME/pylint
+#   expire_in: 2 hrs
 
 #sphinxdoc:
 # image: $CI_REGISTRY/environment:development

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,21 +1,21 @@
-#.test-default: &test-default
-#  only:
-#    refs:
-#      - master
-#      - tags
-#      - branches
-#    changes:
-#      - bim2sim/**/*.py
+.test-default: &test-default
+  only:
+    refs:
+      - master
+      - tags
+      - branches
+    changes:
+      - bim2sim/**/*.py
 
 stages:
-#  - test
-#  - code_quality
-#  - build-env
-#  - build-env-plugins
-#  - build-tool
+  - test
+  - code_quality
+  - build-env
+  - build-env-plugins
+  - build-tool
   - doc
   - deploy
-#  - visualize
+  - visualize
 
 variables:
   # TODO variable inside variable seems not be working on our gitlab instance,
@@ -34,531 +34,486 @@ include:
     file: 'pages/gh-pages.gitlab-ci.yml'
 
 
-#build_env:master:
-# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
-# stage: build-env
-# services:
-#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-#     command: ["--mtu=1440"]
-# before_script:
-#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
-# script:
-#   - docker build -t $CI_REGISTRY/environment:master -f envBase.Dockerfile .
-#   - docker push $CI_REGISTRY/environment:master
-# only:
-#   refs:
-#      - master
-#   changes:
-#      - envBase.Dockerfile
-#      - requirements.txt
-#
-#build_env:development:
-# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
-# stage: build-env
-# services:
-#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-#     command: ["--mtu=1440"]
-# before_script:
-#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
-# script:
-#   - docker build -t $CI_REGISTRY/environment:development -f envBase.Dockerfile .
-#   - docker push $CI_REGISTRY/environment:development
-# only:
-#   refs:
-#      - development
-#   changes:
-#      - envBase.Dockerfile
-#      - requirements.txt
-#      - .gitlab-ci.yml
-#
-#build_env:dymola:
-# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
-# stage: build-env
-# services:
-#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-#     command: ["--mtu=1440"]
-# before_script:
-#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME_DYMOLA -p $CI_DEPLOY_TOKEN_PASSWORD_DYMOLA $CI_REGISTRY_LOGIN_DYMOLA   # login dymola docker reg
-# script:
-#   - docker build -t $CI_REGISTRY/environment:dymola -f envBaseDymola.Dockerfile .
-#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN  # login bim2sim reg
-#   - docker push $CI_REGISTRY/environment:dymola
-# only:
-#   refs:
-#      - development
-#   changes:
-#      - envBaseDymola.Dockerfile
-#      - requirements.txt
-#      - .gitlab-ci.yml
-#
-#
-#build_env:energyplus:
-#  image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
-#  stage: build-env-plugins
-#  services:
-#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-#     command: ["--mtu=1440"]
-#  before_script:
-#    - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
-#  script:
-#    - docker build -t $CI_REGISTRY/environment:energyplus -f bim2sim/plugins/PluginEnergyPlus/envEP.Dockerfile .
-#    - docker push $CI_REGISTRY/environment:energyplus
-#  only:
-#    refs:
-#       - development
-#    changes:
-#       - envBase.Dockerfile
-#       - bim2sim/plugins/PluginEnergyPlus/envEP.Dockerfile
-#       - bim2sim/plugins/PluginEnergyPlus/requirements.txt
-#       - requirements.txt
-#       - .gitlab-ci.yml
-#
-#build_env:cfd:
-# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
-# stage: build-env-plugins
-# services:
-#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-#     command: ["--mtu=1440"]
-# before_script:
-#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
-# script:
-#   - docker build -t $CI_REGISTRY/environment:cfd -f bim2sim/plugins/PluginCFD/envCFD.Dockerfile .
-#   - docker push $CI_REGISTRY/environment:cfd
-# timeout: 6 hours
-# only:
-#   refs:
-#      - development
-#   changes:
-#      - envBase.Dockerfile
-#      - bim2sim/plugins/PluginCFD/envCFD.Dockerfile
-#      - requirements.txt
-#      - .gitlab-ci.yml
-#
-#build_env:teaser:
-# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
-# stage: build-env-plugins
-# services:
-#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-#     command: ["--mtu=1440"]
-# before_script:
-#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
-# script:
-#   - docker build -t $CI_REGISTRY/environment:teaser -f bim2sim/plugins/PluginTEASER/envTEASER.Dockerfile .
-#   - docker push $CI_REGISTRY/environment:teaser
-# only:
-#   refs:
-#     - development
-#   changes:
-#     - envBase.Dockerfile
-#     - bim2sim/plugins/PluginTEASER/requirements.txt
-#     - bim2sim/plugins/PluginTEASER/envTEASER.Dockerfile
-#     - requirements.txt
-#     - .gitlab-ci.yml
-#
-#
-#build_env:teaser-dymola:
-# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
-# stage: build-env-plugins
-# services:
-#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-#     command: ["--mtu=1440"]
-# before_script:
-#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
-# script:
-#   - docker build -t $CI_REGISTRY/environment:teaser-dymola -f bim2sim/plugins/PluginTEASER/envTEASER-dymola.Dockerfile .
-#   - docker push $CI_REGISTRY/environment:teaser-dymola
-# only:
-#   refs:
-#     - development
-#   changes:
-#     - envBase.Dockerfile
-#     - bim2sim/plugins/PluginTEASER/requirements.txt
-#     - bim2sim/plugins/PluginTEASER/envTEASER.Dockerfile
-#     - requirements.txt
-#     - .gitlab-ci.yml
-#
-#
-#build_env:aixlib:
-# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
-# stage: build-env-plugins
-# services:
-#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-#     command: ["--mtu=1440"]
-# before_script:
-#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
-# script:
-#   - docker build -t $CI_REGISTRY/environment:aixlib -f bim2sim/plugins/PluginAixLib/envAixLib.Dockerfile .
-#   - docker push $CI_REGISTRY/environment:aixlib
-# only:
-#   refs:
-#     - development
-#   changes:
-#     - envBase.Dockerfile
-#     - bim2sim/plugins/PluginAixLib/requirements.txt
-#     - bim2sim/plugins/PluginAixLib/envAixLib.Dockerfile
-#     - requirements.txt
-#     - .gitlab-ci.yml
-#
-#build_tool:release:
-# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
-# stage: build-tool
-# services:
-#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-#     command: ["--mtu=1440"]
-# before_script:
-#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
-# script:
-#   - docker build -t $CI_REGISTRY/tool:latest .
-#   - docker push $CI_REGISTRY/tool:latest
-# only:
-#   - master
-#
-#build_tool:development:
-# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
-# stage: build-tool
-# services:
-#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-#     command: ["--mtu=1440"]
-# before_script:
-#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
-# script:
-#   - docker build -t $CI_REGISTRY/tool:development .
-#   - docker push $CI_REGISTRY/tool:development
-# only:
-#   - development
-#
-#build_tool:webdevelop:
-# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
-# stage: build-tool
-# services:
-#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-#     command: ["--mtu=1440"]
-# before_script:
-#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
-# script:
-#   - docker build -t $CI_REGISTRY/tool:web_develop -f total.Dockerfile .
-#   - docker push $CI_REGISTRY/tool:web_develop
-# only:
-#   - development
-#
-#build_tool:cfd:
-# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
-# stage: build-tool
-# services:
-#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-#     command: ["--mtu=1440"]
-# before_script:
-#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
-# script:
-#   - docker build -t $CI_REGISTRY/tool:cfd -f bim2sim/plugins/PluginCFD/cfd.Dockerfile .
-#   - docker push $CI_REGISTRY/tool:cfd
-# only:
-#   changes:
-#      - bim2sim/plugins/PluginCFD/*
-#
-#build_tool:teaser:
-# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
-# stage: build-tool
-# services:
-#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-#     command: ["--mtu=1440"]
-# before_script:
-#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
-# script:
-#   - docker build -t $CI_REGISTRY/tool:teaser -f bim2sim/plugins/PluginTEASER/teaser.Dockerfile .
-#   - docker push $CI_REGISTRY/tool:teaser
-# only:
-#   changes:
-#      - bim2sim/plugins/PluginTEASER/*
-#
-#build_tool:aixlib:
-# image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
-# stage: build-tool
-# services:
-#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-#     command: ["--mtu=1440"]
-# before_script:
-#   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
-# script:
-#   - docker build -t $CI_REGISTRY/tool:aixlib -f bim2sim/plugins/PluginAixLib/aixlib.Dockerfile .
-#   - docker push $CI_REGISTRY/tool:aixlib
-# only:
-#   changes:
-#      - bim2sim/plugins/PluginAixLib/*
-#
-#test_Base:
-#  <<: *test-default
-#  image: $CI_REGISTRY/environment:development
-#  stage: test
-#  services:
-#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-#     command: ["--mtu=1440"]
-#  before_script:
-#    - pip install coverage
-#    - pip install coverage-badge
-#  script:
-#    - mv ./* /bim2sim-coding/
-#    - cd /bim2sim-coding
-#    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=hydraulic --force_new
-#    - coverage run -m unittest discover /bim2sim-coding/test
-#    - coverage report -i
-#    - mkdir -p $CI_COMMIT_REF_NAME/coverage
-#    - coverage html -i
-#    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
-#    # skip this for now as its only cosmetic and leads to problems
-#    # - coverage-badge -o coverage.svg
-#    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
-#  artifacts:
-#    paths:
-#    - $CI_COMMIT_REF_NAME/coverage
-#
-#test_EP:
-#  <<: *test-default
-#  image: $CI_REGISTRY/environment:energyplus
-#  stage: test
-#  services:
-#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-#     command: ["--mtu=1440"]
-#  before_script:
-#    - pip install coverage
-#    - pip install coverage-badge
-#  script:
-#    - mv ./* /bim2sim-coding/
-#    - cd /bim2sim-coding
-#    - cat /bim2sim-coding/bim2sim/plugins/PluginEnergyPlus/data/Minimal.idf
-#    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new
-#    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginEnergyPlus/test/integration
-#    - coverage report -i
-#    - mkdir -p $CI_COMMIT_REF_NAME/coverage
-#    - coverage html -i
-#    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
-#    # skip this for now as its only cosmetic and leads to problems
-#    # - coverage-badge -o coverage.svg
-#    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
-#  artifacts:
-#    paths:
-#    - $CI_COMMIT_REF_NAME/coverage
-#
-#test_EP_regression:
-#  <<: *test-default
-#  image: $CI_REGISTRY/environment:energyplus
-#  stage: test
-#  before_script:
-#    - pip install coverage
-#    - pip install coverage-badge
-#  script:
-#    - mv ./* /bim2sim-coding/
-#    - cd /bim2sim-coding
-#    - cat /bim2sim-coding/bim2sim/plugins/PluginEnergyPlus/data/Minimal.idf
-#    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new --with_regression
-#    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginEnergyPlus/test/regression
-#    - coverage report -i
-#    - mkdir -p $CI_COMMIT_REF_NAME/coverage
-#    - coverage html -i
-#    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
-#    # skip this for now as its only cosmetic and leads to problems
-#    # - coverage-badge -o coverage.svg
-#    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
-#  artifacts:
-#    paths:
-#    - $CI_COMMIT_REF_NAME/coverage
-#
-#test_TEASER:
-#  <<: *test-default
-#  image: $CI_REGISTRY/environment:teaser
-#  stage: test
-#  services:
-#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-#     command: ["--mtu=1440"]
-#  before_script:
-#    - pip install coverage
-#    - pip install coverage-badge
-#  script:
-#    - mv ./* /bim2sim-coding/
-#    - cd /bim2sim-coding
-#    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new
-#    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginTEASER/test/integration
-#    - coverage report -i
-#    - mkdir -p $CI_COMMIT_REF_NAME/coverage
-#    - coverage html -i
-#    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
-#    # skip this for now as its only cosmetic and leads to problems
-#    # - coverage-badge -o coverage.svg
-#    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
-#  artifacts:
-#    paths:
-#    - $CI_COMMIT_REF_NAME/coverage
-#
-#test_TEASER_regression:
-#  <<: *test-default
-#  image: $CI_REGISTRY/environment:teaser-dymola
-#  stage: test
-#  before_script:
-#    - pip install coverage
-#    - pip install coverage-badge
-#  script:
-#    - mv ./* /bim2sim-coding/
-#    - cd /bim2sim-coding
-#    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new --with_regression
-#    - xvfb-run -n 77 coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginTEASER/test/regression
-#    - coverage report -i
-#    - mkdir -p $CI_COMMIT_REF_NAME/coverage
-#    - coverage html -i
-#    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
-#    # skip this for now as its only cosmetic and leads to problems
-#    # - coverage-badge -o coverage.svg
-#    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
-#  artifacts:
-#    paths:
-#    - $CI_COMMIT_REF_NAME/coverage
-#
-#test_CFD:
-#  <<: *test-default
-#  image: $CI_REGISTRY/environment:cfd
-#  stage: test
-#  services:
-#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-#     command: ["--mtu=1440"]
-#  before_script:
-#    - pip install coverage
-#    - pip install coverage-badge
-#  script:
-#    - mv ./* /bim2sim-coding/
-#    - cd /bim2sim-coding
-#    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new
-#    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginCFD/test/integration
-#    - coverage report -i
-#    - mkdir -p $CI_COMMIT_REF_NAME/coverage
-#    - coverage html -i
-#    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
-#    # skip this for now as its only cosmetic and leads to problems
-#    # - coverage-badge -o coverage.svg
-#    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
-#  artifacts:
-#    paths:
-#    - $CI_COMMIT_REF_NAME/coverage
-#
-#test_AixLib:
-#  <<: *test-default
-#  image: $CI_REGISTRY/environment:aixlib
-#  stage: test
-#  services:
-#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-#     command: ["--mtu=1440"]
-#  before_script:
-#    - pip install coverage
-#    - pip install coverage-badge
-#  script:
-#    - mv ./* /bim2sim-coding/
-#    - cd /bim2sim-coding
-#    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=hydraulic --force_new
-#    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginAixLib/test/integration
-#    - coverage report -i
-#    - mkdir -p $CI_COMMIT_REF_NAME/coverage
-#    - coverage html -i
-#    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
-#    # skip this for now as its only cosmetic and leads to problems
-#    # - coverage-badge -o coverage.svg
-#    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
-#  artifacts:
-#    paths:
-#    - $CI_COMMIT_REF_NAME/coverage
-#
-#test_LCA:
-#  <<: *test-default
-#  image: $CI_REGISTRY/environment:development
-#  stage: test
-#  before_script:
-#    - pip install coverage
-#    - pip install coverage-badge
-#  script:
-#    - mv ./* /bim2sim-coding/
-#    - cd /bim2sim-coding
-#    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new
-#    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginLCA/test/integration
-#    - coverage report -i
-#    - mkdir -p $CI_COMMIT_REF_NAME/coverage
-#    - coverage html -i
-#    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
-#    # skip this for now as its only cosmetic and leads to problems
-#    # - coverage-badge -o coverage.svg
-#    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
-#  artifacts:
-#    paths:
-#    - $CI_COMMIT_REF_NAME/coverage
-#
-#
-#pylint:
-# <<: *test-default
-# stage: code_quality
-# image: python:3.6
-# services:
-#   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-#     command: ["--mtu=1440"]
-# before_script:
-#   - pip install pylint pylint-json2html anybadge --quiet
-# script:
-#    - mkdir -p $CI_COMMIT_REF_NAME/pylint
-#    # Determine code to check: in a user-defined directory, or module with the project name, or all python files
-#    # (In case of using the project name, make project-name pep8 lowercase to be detected by pylint)
-#    - if [ ! -z "$PYLINT_INPUT" ];
-#      then echo "Using user-defined source dir";
-#      elif [ -d "$CI_PROJECT_NAME" ];
-#      then echo "Using repo name as module name" && PYLINT_INPUT=`echo "$CI_PROJECT_NAME" | tr '[:upper:]' '[:lower:]'`;
-#      else echo "Checking all python files" && PYLINT_INPUT="**/*.py";
-#      fi
-#    # Run pylint on the python-project
-#    - pylint --output-format=text $PYLINT_INPUT --exit-zero | tee $CI_COMMIT_REF_NAME/pylint/pylint.txt
-#    - score=$(sed -n 's/^Your code has been rated at \([-0-9.]*\)\/.*/\1/p' $CI_COMMIT_REF_NAME/pylint/pylint.txt)
-#    - anybadge --value=$score --file=$CI_COMMIT_REF_NAME/pylint/pylint.svg pylint
-#    - pylint --output-format=jsonextended --load-plugins=pylint_json2html --exit-zero $PYLINT_INPUT | tee $CI_COMMIT_REF_NAME/pylint/pylint.json
-#    - pylint-json2html -f jsonextended -o $CI_COMMIT_REF_NAME/pylint/pylint.html < $CI_COMMIT_REF_NAME/pylint/pylint.json
-# artifacts:
-#   paths:
-#   - $CI_COMMIT_REF_NAME/pylint
-#   expire_in: 2 hrs
+build_env:master:
+ image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+ stage: build-env
+ services:
+   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+     command: ["--mtu=1440"]
+ before_script:
+   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+ script:
+   - docker build -t $CI_REGISTRY/environment:master -f envBase.Dockerfile .
+   - docker push $CI_REGISTRY/environment:master
+ only:
+   refs:
+      - master
+   changes:
+      - envBase.Dockerfile
+      - requirements.txt
 
-#sphinxdoc:
-# image: $CI_REGISTRY/environment:development
-# stage: doc
-# services:
-#  - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-#    command: ["--mtu=1440"]
-# before_script:
-#   - mv ./* /bim2sim-coding/
-#   - pip install -r /bim2sim-coding/docs/requirements.txt
-# script:
-#   - mkdir -p $CI_COMMIT_REF_NAME/docs
-#   - sphinx-apidoc -M -o /bim2sim-coding/docs/source/code /bim2sim-coding  # create rst files for all python files
-#   - sphinx-build -b html /bim2sim-coding/docs/source $CI_COMMIT_REF_NAME/docs
-#   - anybadge --value="passing" --file=$CI_COMMIT_REF_NAME/docs/doc.svg --label documentation
-#
-# artifacts:
-#   paths:
-#   - $CI_COMMIT_REF_NAME/docs
-#   expire_in: 2 hrs
+build_env:development:
+ image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+ stage: build-env
+ services:
+   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+     command: ["--mtu=1440"]
+ before_script:
+   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+ script:
+   - docker build -t $CI_REGISTRY/environment:development -f envBase.Dockerfile .
+   - docker push $CI_REGISTRY/environment:development
+ only:
+   refs:
+      - development
+   changes:
+      - envBase.Dockerfile
+      - requirements.txt
+      - .gitlab-ci.yml
 
-#pages:
-## Page to generate content to be downloaded in the artifact-section.
-# image: ubuntu:latest
-# stage: deploy
-# before_script:
-#   - apt-get update -y
-#   - apt-get install zip unzip -y
-#   - apt-get install curl -y
-# script:
-#   - set -e
-#   # get existing content with branch artifacts
-#   - curl --fail --header "PRIVATE-TOKEN:$GL_TOKEN" $CI_PAGES_URL/content.zip -o content.zip
-#   - if [ -e "content.zip" ]; then unzip "content.zip"; rm "content.zip"; fi
-#   # delete all branch folders older than 14 days which are not master or development
-#   - find public/* -maxdepth 0 -type d -not -name "development" -not -name "master" -mtime +14 -exec rm -rf {} \;
-#   # Add/update content
-#   - mkdir -p public/$CI_COMMIT_REF_NAME
-#   - cp -r $CI_COMMIT_REF_NAME/* public/$CI_COMMIT_REF_NAME
-#   # Zip the content and publish the zip again
-#   - zip -r "content.zip" "public"
-#   - mv "content.zip" "public/"
-# artifacts:
-#   paths:
-#     - public
+build_env:dymola:
+ image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+ stage: build-env
+ services:
+   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+     command: ["--mtu=1440"]
+ before_script:
+   - docker login -u $CI_DEPLOY_TOKEN_USERNAME_DYMOLA -p $CI_DEPLOY_TOKEN_PASSWORD_DYMOLA $CI_REGISTRY_LOGIN_DYMOLA   # login dymola docker reg
+ script:
+   - docker build -t $CI_REGISTRY/environment:dymola -f envBaseDymola.Dockerfile .
+   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN  # login bim2sim reg
+   - docker push $CI_REGISTRY/environment:dymola
+ only:
+   refs:
+      - development
+   changes:
+      - envBaseDymola.Dockerfile
+      - requirements.txt
+      - .gitlab-ci.yml
+
+
+build_env:energyplus:
+  image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+  stage: build-env-plugins
+  services:
+   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+     command: ["--mtu=1440"]
+  before_script:
+    - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+  script:
+    - docker build -t $CI_REGISTRY/environment:energyplus -f bim2sim/plugins/PluginEnergyPlus/envEP.Dockerfile .
+    - docker push $CI_REGISTRY/environment:energyplus
+  only:
+    refs:
+       - development
+    changes:
+       - envBase.Dockerfile
+       - bim2sim/plugins/PluginEnergyPlus/envEP.Dockerfile
+       - bim2sim/plugins/PluginEnergyPlus/requirements.txt
+       - requirements.txt
+       - .gitlab-ci.yml
+
+build_env:cfd:
+ image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+ stage: build-env-plugins
+ services:
+   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+     command: ["--mtu=1440"]
+ before_script:
+   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+ script:
+   - docker build -t $CI_REGISTRY/environment:cfd -f bim2sim/plugins/PluginCFD/envCFD.Dockerfile .
+   - docker push $CI_REGISTRY/environment:cfd
+ timeout: 6 hours
+ only:
+   refs:
+      - development
+   changes:
+      - envBase.Dockerfile
+      - bim2sim/plugins/PluginCFD/envCFD.Dockerfile
+      - requirements.txt
+      - .gitlab-ci.yml
+
+build_env:teaser:
+ image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+ stage: build-env-plugins
+ services:
+   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+     command: ["--mtu=1440"]
+ before_script:
+   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+ script:
+   - docker build -t $CI_REGISTRY/environment:teaser -f bim2sim/plugins/PluginTEASER/envTEASER.Dockerfile .
+   - docker push $CI_REGISTRY/environment:teaser
+ only:
+   refs:
+     - development
+   changes:
+     - envBase.Dockerfile
+     - bim2sim/plugins/PluginTEASER/requirements.txt
+     - bim2sim/plugins/PluginTEASER/envTEASER.Dockerfile
+     - requirements.txt
+     - .gitlab-ci.yml
+
+
+build_env:teaser-dymola:
+ image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+ stage: build-env-plugins
+ services:
+   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+     command: ["--mtu=1440"]
+ before_script:
+   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+ script:
+   - docker build -t $CI_REGISTRY/environment:teaser-dymola -f bim2sim/plugins/PluginTEASER/envTEASER-dymola.Dockerfile .
+   - docker push $CI_REGISTRY/environment:teaser-dymola
+ only:
+   refs:
+     - development
+   changes:
+     - envBase.Dockerfile
+     - bim2sim/plugins/PluginTEASER/requirements.txt
+     - bim2sim/plugins/PluginTEASER/envTEASER.Dockerfile
+     - requirements.txt
+     - .gitlab-ci.yml
+
+
+build_env:aixlib:
+ image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+ stage: build-env-plugins
+ services:
+   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+     command: ["--mtu=1440"]
+ before_script:
+   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+ script:
+   - docker build -t $CI_REGISTRY/environment:aixlib -f bim2sim/plugins/PluginAixLib/envAixLib.Dockerfile .
+   - docker push $CI_REGISTRY/environment:aixlib
+ only:
+   refs:
+     - development
+   changes:
+     - envBase.Dockerfile
+     - bim2sim/plugins/PluginAixLib/requirements.txt
+     - bim2sim/plugins/PluginAixLib/envAixLib.Dockerfile
+     - requirements.txt
+     - .gitlab-ci.yml
+
+build_tool:release:
+ image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+ stage: build-tool
+ services:
+   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+     command: ["--mtu=1440"]
+ before_script:
+   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+ script:
+   - docker build -t $CI_REGISTRY/tool:latest .
+   - docker push $CI_REGISTRY/tool:latest
+ only:
+   - master
+
+build_tool:development:
+ image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+ stage: build-tool
+ services:
+   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+     command: ["--mtu=1440"]
+ before_script:
+   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+ script:
+   - docker build -t $CI_REGISTRY/tool:development .
+   - docker push $CI_REGISTRY/tool:development
+ only:
+   - development
+
+build_tool:webdevelop:
+ image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+ stage: build-tool
+ services:
+   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+     command: ["--mtu=1440"]
+ before_script:
+   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+ script:
+   - docker build -t $CI_REGISTRY/tool:web_develop -f total.Dockerfile .
+   - docker push $CI_REGISTRY/tool:web_develop
+ only:
+   - development
+
+build_tool:cfd:
+ image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+ stage: build-tool
+ services:
+   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+     command: ["--mtu=1440"]
+ before_script:
+   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+ script:
+   - docker build -t $CI_REGISTRY/tool:cfd -f bim2sim/plugins/PluginCFD/cfd.Dockerfile .
+   - docker push $CI_REGISTRY/tool:cfd
+ only:
+   changes:
+      - bim2sim/plugins/PluginCFD/*
+
+build_tool:teaser:
+ image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+ stage: build-tool
+ services:
+   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+     command: ["--mtu=1440"]
+ before_script:
+   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+ script:
+   - docker build -t $CI_REGISTRY/tool:teaser -f bim2sim/plugins/PluginTEASER/teaser.Dockerfile .
+   - docker push $CI_REGISTRY/tool:teaser
+ only:
+   changes:
+      - bim2sim/plugins/PluginTEASER/*
+
+build_tool:aixlib:
+ image: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_20.10.23
+ stage: build-tool
+ services:
+   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+     command: ["--mtu=1440"]
+ before_script:
+   - docker login -u $CI_DEPLOY_TOKEN_USERNAME -p $CI_DEPLOY_TOKEN_PASSWORD $CI_REGISTRY_LOGIN
+ script:
+   - docker build -t $CI_REGISTRY/tool:aixlib -f bim2sim/plugins/PluginAixLib/aixlib.Dockerfile .
+   - docker push $CI_REGISTRY/tool:aixlib
+ only:
+   changes:
+      - bim2sim/plugins/PluginAixLib/*
+
+test_Base:
+  <<: *test-default
+  image: $CI_REGISTRY/environment:development
+  stage: test
+  services:
+   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+     command: ["--mtu=1440"]
+  before_script:
+    - pip install coverage
+    - pip install coverage-badge
+  script:
+    - mv ./* /bim2sim-coding/
+    - cd /bim2sim-coding
+    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=hydraulic --force_new
+    - coverage run -m unittest discover /bim2sim-coding/test
+    - coverage report -i
+    - mkdir -p $CI_COMMIT_REF_NAME/coverage
+    - coverage html -i
+    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
+    # skip this for now as its only cosmetic and leads to problems
+    # - coverage-badge -o coverage.svg
+    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
+  artifacts:
+    paths:
+    - $CI_COMMIT_REF_NAME/coverage
+
+test_EP:
+  <<: *test-default
+  image: $CI_REGISTRY/environment:energyplus
+  stage: test
+  services:
+   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+     command: ["--mtu=1440"]
+  before_script:
+    - pip install coverage
+    - pip install coverage-badge
+  script:
+    - mv ./* /bim2sim-coding/
+    - cd /bim2sim-coding
+    - cat /bim2sim-coding/bim2sim/plugins/PluginEnergyPlus/data/Minimal.idf
+    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new
+    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginEnergyPlus/test/integration
+    - coverage report -i
+    - mkdir -p $CI_COMMIT_REF_NAME/coverage
+    - coverage html -i
+    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
+    # skip this for now as its only cosmetic and leads to problems
+    # - coverage-badge -o coverage.svg
+    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
+  artifacts:
+    paths:
+    - $CI_COMMIT_REF_NAME/coverage
+
+test_EP_regression:
+  <<: *test-default
+  image: $CI_REGISTRY/environment:energyplus
+  stage: test
+  before_script:
+    - pip install coverage
+    - pip install coverage-badge
+  script:
+    - mv ./* /bim2sim-coding/
+    - cd /bim2sim-coding
+    - cat /bim2sim-coding/bim2sim/plugins/PluginEnergyPlus/data/Minimal.idf
+    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new --with_regression
+    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginEnergyPlus/test/regression
+    - coverage report -i
+    - mkdir -p $CI_COMMIT_REF_NAME/coverage
+    - coverage html -i
+    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
+    # skip this for now as its only cosmetic and leads to problems
+    # - coverage-badge -o coverage.svg
+    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
+  artifacts:
+    paths:
+    - $CI_COMMIT_REF_NAME/coverage
+
+test_TEASER:
+  <<: *test-default
+  image: $CI_REGISTRY/environment:teaser
+  stage: test
+  services:
+   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+     command: ["--mtu=1440"]
+  before_script:
+    - pip install coverage
+    - pip install coverage-badge
+  script:
+    - mv ./* /bim2sim-coding/
+    - cd /bim2sim-coding
+    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new
+    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginTEASER/test/integration
+    - coverage report -i
+    - mkdir -p $CI_COMMIT_REF_NAME/coverage
+    - coverage html -i
+    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
+    # skip this for now as its only cosmetic and leads to problems
+    # - coverage-badge -o coverage.svg
+    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
+  artifacts:
+    paths:
+    - $CI_COMMIT_REF_NAME/coverage
+
+test_TEASER_regression:
+  <<: *test-default
+  image: $CI_REGISTRY/environment:teaser-dymola
+  stage: test
+  before_script:
+    - pip install coverage
+    - pip install coverage-badge
+  script:
+    - mv ./* /bim2sim-coding/
+    - cd /bim2sim-coding
+    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new --with_regression
+    - xvfb-run -n 77 coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginTEASER/test/regression
+    - coverage report -i
+    - mkdir -p $CI_COMMIT_REF_NAME/coverage
+    - coverage html -i
+    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
+    # skip this for now as its only cosmetic and leads to problems
+    # - coverage-badge -o coverage.svg
+    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
+  artifacts:
+    paths:
+    - $CI_COMMIT_REF_NAME/coverage
+
+test_CFD:
+  <<: *test-default
+  image: $CI_REGISTRY/environment:cfd
+  stage: test
+  services:
+   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+     command: ["--mtu=1440"]
+  before_script:
+    - pip install coverage
+    - pip install coverage-badge
+  script:
+    - mv ./* /bim2sim-coding/
+    - cd /bim2sim-coding
+    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new
+    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginCFD/test/integration
+    - coverage report -i
+    - mkdir -p $CI_COMMIT_REF_NAME/coverage
+    - coverage html -i
+    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
+    # skip this for now as its only cosmetic and leads to problems
+    # - coverage-badge -o coverage.svg
+    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
+  artifacts:
+    paths:
+    - $CI_COMMIT_REF_NAME/coverage
+
+test_AixLib:
+  <<: *test-default
+  image: $CI_REGISTRY/environment:aixlib
+  stage: test
+  services:
+   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+     command: ["--mtu=1440"]
+  before_script:
+    - pip install coverage
+    - pip install coverage-badge
+  script:
+    - mv ./* /bim2sim-coding/
+    - cd /bim2sim-coding
+    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=hydraulic --force_new
+    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginAixLib/test/integration
+    - coverage report -i
+    - mkdir -p $CI_COMMIT_REF_NAME/coverage
+    - coverage html -i
+    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
+    # skip this for now as its only cosmetic and leads to problems
+    # - coverage-badge -o coverage.svg
+    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
+  artifacts:
+    paths:
+    - $CI_COMMIT_REF_NAME/coverage
+
+test_LCA:
+  <<: *test-default
+  image: $CI_REGISTRY/environment:development
+  stage: test
+  before_script:
+    - pip install coverage
+    - pip install coverage-badge
+  script:
+    - mv ./* /bim2sim-coding/
+    - cd /bim2sim-coding
+    - python /bim2sim-coding/test/resources/dl_test_resources.py --domain=arch --force_new
+    - coverage run -m unittest discover /bim2sim-coding/bim2sim/plugins/PluginLCA/test/integration
+    - coverage report -i
+    - mkdir -p $CI_COMMIT_REF_NAME/coverage
+    - coverage html -i
+    - cp htmlcov/* $CI_COMMIT_REF_NAME/coverage/
+    # skip this for now as its only cosmetic and leads to problems
+    # - coverage-badge -o coverage.svg
+    # - cp coverage.svg $CI_COMMIT_REF_NAME/coverage/
+  artifacts:
+    paths:
+    - $CI_COMMIT_REF_NAME/coverage
+
+
+pylint:
+ <<: *test-default
+ stage: code_quality
+ image: python:3.6
+ services:
+   - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+     command: ["--mtu=1440"]
+ before_script:
+   - pip install pylint pylint-json2html anybadge --quiet
+ script:
+    - mkdir -p $CI_COMMIT_REF_NAME/pylint
+    # Determine code to check: in a user-defined directory, or module with the project name, or all python files
+    # (In case of using the project name, make project-name pep8 lowercase to be detected by pylint)
+    - if [ ! -z "$PYLINT_INPUT" ];
+      then echo "Using user-defined source dir";
+      elif [ -d "$CI_PROJECT_NAME" ];
+      then echo "Using repo name as module name" && PYLINT_INPUT=`echo "$CI_PROJECT_NAME" | tr '[:upper:]' '[:lower:]'`;
+      else echo "Checking all python files" && PYLINT_INPUT="**/*.py";
+      fi
+    # Run pylint on the python-project
+    - pylint --output-format=text $PYLINT_INPUT --exit-zero | tee $CI_COMMIT_REF_NAME/pylint/pylint.txt
+    - score=$(sed -n 's/^Your code has been rated at \([-0-9.]*\)\/.*/\1/p' $CI_COMMIT_REF_NAME/pylint/pylint.txt)
+    - anybadge --value=$score --file=$CI_COMMIT_REF_NAME/pylint/pylint.svg pylint
+    - pylint --output-format=jsonextended --load-plugins=pylint_json2html --exit-zero $PYLINT_INPUT | tee $CI_COMMIT_REF_NAME/pylint/pylint.json
+    - pylint-json2html -f jsonextended -o $CI_COMMIT_REF_NAME/pylint/pylint.html < $CI_COMMIT_REF_NAME/pylint/pylint.json
+ artifacts:
+   paths:
+   - $CI_COMMIT_REF_NAME/pylint
+   expire_in: 2 hrs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,8 +21,8 @@ variables:
   # TODO variable inside variable seems not be working on our gitlab instance,
   # see post below, therefore use hardcoded image here for sphinx job
   # https://stackoverflow.com/questions/67005507/variable-inside-variable-gitlab-ci
-  PYTHON_VERSION: "registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:python_3.9"
-#  PYTHON_VERSION: "registry.git.rwth-aachen.de/ebc/ebc_all/github_ci/bim2sim/environment:development"
+#  PYTHON_VERSION: "registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:python_3.9"
+  PYTHON_VERSION: "registry.git.rwth-aachen.de/ebc/ebc_all/github_ci/bim2sim/environment:development"
 #  PYTHON_VERSION: "${CI_REGISTRY}/environment:development"
   GIT_SUBMODULE_STRATEGY: recursive
   GH_REPO_URL: "git@github.com:BIM2SIM/bim2sim.git"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,14 +8,14 @@
       - bim2sim/**/*.py
 
 stages:
-  - test
-  - code_quality
-  - build-env
-  - build-env-plugins
-  - build-tool
+#  - test
+#  - code_quality
+#  - build-env
+#  - build-env-plugins
+#  - build-tool
   - doc
   - deploy
-  - visualize
+#  - visualize
 
 variables:
   PYTHON_VERSION: "$CI_REGISTRY/environment:development"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,11 @@ stages:
 #  - visualize
 
 variables:
-  PYTHON_VERSION: "registry.git.rwth-aachen.de/ebc/ebc_all/github_ci/bim2sim/environment:development"
+  # TODO variable inside variable seems not be working on our gitlab instance,
+  # see post below, therefore use hardcoded image here for sphinx job
+  # https://stackoverflow.com/questions/67005507/variable-inside-variable-gitlab-ci
+  PYTHON_VERSION: "registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:python_3.9"
+#  PYTHON_VERSION: "registry.git.rwth-aachen.de/ebc/ebc_all/github_ci/bim2sim/environment:development"
 #  PYTHON_VERSION: "${CI_REGISTRY}/environment:development"
   GIT_SUBMODULE_STRATEGY: recursive
   GH_REPO_URL: "git@github.com:BIM2SIM/bim2sim.git"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,11 +1,11 @@
-.test-default: &test-default
-  only:
-    refs:
-      - master
-      - tags
-      - branches
-    changes:
-      - bim2sim/**/*.py
+#.test-default: &test-default
+#  only:
+#    refs:
+#      - master
+#      - tags
+#      - branches
+#    changes:
+#      - bim2sim/**/*.py
 
 stages:
 #  - test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ stages:
 #  - visualize
 
 variables:
-  PYTHON_VERSION: "$CI_REGISTRY/environment:development"
+  PYTHON_VERSION: "registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:python_3.9"
   GIT_SUBMODULE_STRATEGY: recursive
 
 include:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ stages:
 #  - visualize
 
 variables:
-  PYTHON_VERSION: "registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:python_3.9"
+  PYTHON_VERSION: "${CI_REGISTRY}/environment:development"
   GIT_SUBMODULE_STRATEGY: recursive
 
 include:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,12 @@ stages:
   - deploy
   - visualize
 
+include:
+  - project: 'EBC/EBC_all/gitlab_ci/templates'
+    file: 'python/doc/sphinxdoc.gitlab-ci.yml'
+  - project: 'EBC/EBC_all/gitlab_ci/templates'
+    file: 'pages/gh-pages.gitlab-ci.yml'
+
 variables:
   GIT_SUBMODULE_STRATEGY: recursive
 
@@ -504,47 +510,47 @@ pylint:
    - $CI_COMMIT_REF_NAME/pylint
    expire_in: 2 hrs
 
-sphinxdoc:
- image: $CI_REGISTRY/environment:development
- stage: doc
- services:
-  - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
-    command: ["--mtu=1440"]
- before_script:
-   - mv ./* /bim2sim-coding/
-   - pip install -r /bim2sim-coding/docs/requirements.txt
- script:
-   - mkdir -p $CI_COMMIT_REF_NAME/docs
-   - sphinx-apidoc -M -o /bim2sim-coding/docs/source/code /bim2sim-coding  # create rst files for all python files
-   - sphinx-build -b html /bim2sim-coding/docs/source $CI_COMMIT_REF_NAME/docs
-   - anybadge --value="passing" --file=$CI_COMMIT_REF_NAME/docs/doc.svg --label documentation
+#sphinxdoc:
+# image: $CI_REGISTRY/environment:development
+# stage: doc
+# services:
+#  - name: registry.git.rwth-aachen.de/ebc/ebc_all/gitlab_ci/templates:docker_18.09.7-dind
+#    command: ["--mtu=1440"]
+# before_script:
+#   - mv ./* /bim2sim-coding/
+#   - pip install -r /bim2sim-coding/docs/requirements.txt
+# script:
+#   - mkdir -p $CI_COMMIT_REF_NAME/docs
+#   - sphinx-apidoc -M -o /bim2sim-coding/docs/source/code /bim2sim-coding  # create rst files for all python files
+#   - sphinx-build -b html /bim2sim-coding/docs/source $CI_COMMIT_REF_NAME/docs
+#   - anybadge --value="passing" --file=$CI_COMMIT_REF_NAME/docs/doc.svg --label documentation
+#
+# artifacts:
+#   paths:
+#   - $CI_COMMIT_REF_NAME/docs
+#   expire_in: 2 hrs
 
- artifacts:
-   paths:
-   - $CI_COMMIT_REF_NAME/docs
-   expire_in: 2 hrs
-
-pages:
-# Page to generate content to be downloaded in the artifact-section.
- image: ubuntu:latest
- stage: deploy
- before_script:
-   - apt-get update -y
-   - apt-get install zip unzip -y
-   - apt-get install curl -y
- script:
-   - set -e
-   # get existing content with branch artifacts
-   - curl --fail --header "PRIVATE-TOKEN:$GL_TOKEN" $CI_PAGES_URL/content.zip -o content.zip
-   - if [ -e "content.zip" ]; then unzip "content.zip"; rm "content.zip"; fi
-   # delete all branch folders older than 14 days which are not master or development
-   - find public/* -maxdepth 0 -type d -not -name "development" -not -name "master" -mtime +14 -exec rm -rf {} \;
-   # Add/update content
-   - mkdir -p public/$CI_COMMIT_REF_NAME
-   - cp -r $CI_COMMIT_REF_NAME/* public/$CI_COMMIT_REF_NAME
-   # Zip the content and publish the zip again
-   - zip -r "content.zip" "public"
-   - mv "content.zip" "public/"
- artifacts:
-   paths:
-     - public
+#pages:
+## Page to generate content to be downloaded in the artifact-section.
+# image: ubuntu:latest
+# stage: deploy
+# before_script:
+#   - apt-get update -y
+#   - apt-get install zip unzip -y
+#   - apt-get install curl -y
+# script:
+#   - set -e
+#   # get existing content with branch artifacts
+#   - curl --fail --header "PRIVATE-TOKEN:$GL_TOKEN" $CI_PAGES_URL/content.zip -o content.zip
+#   - if [ -e "content.zip" ]; then unzip "content.zip"; rm "content.zip"; fi
+#   # delete all branch folders older than 14 days which are not master or development
+#   - find public/* -maxdepth 0 -type d -not -name "development" -not -name "master" -mtime +14 -exec rm -rf {} \;
+#   # Add/update content
+#   - mkdir -p public/$CI_COMMIT_REF_NAME
+#   - cp -r $CI_COMMIT_REF_NAME/* public/$CI_COMMIT_REF_NAME
+#   # Zip the content and publish the zip again
+#   - zip -r "content.zip" "public"
+#   - mv "content.zip" "public/"
+# artifacts:
+#   paths:
+#     - public

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ The focus of the currently released tool is on BPS and HVAC but we already provi
 ![Toolchain](docs/source/img/static/bim2sim_project_workflow_eng.png)
 
 ## Installation and Usage
-You can find detailed documentation and description how to install and to use in our [documentation](https://ebc.pages.rwth-aachen.de/EBC_all/github_ci/bim2sim/development/docs/overview.html). We recommend reading at least:
-* [Big Picture](https://ebc.pages.rwth-aachen.de/EBC_all/github_ci/bim2sim/development/docs/overview.html)
-* [Installation](https://ebc.pages.rwth-aachen.de/EBC_all/github_ci/bim2sim/development/docs/installation.html)
-* [First Steps](https://ebc.pages.rwth-aachen.de/EBC_all/github_ci/bim2sim/development/docs/first-steps.html)
+You can find detailed documentation and description how to install and to use in our [documentation](https://bim2sim.github.io/bim2sim//development/docs/overview.html). We recommend reading at least:
+* [Big Picture](https://bim2sim.github.io/bim2sim//development/docs/overview.html)
+* [Installation](https://bim2sim.github.io/bim2sim//development/docs/installation.html)
+* [First Steps](https://bim2sim.github.io/bim2sim//development/docs/first-steps.html)
 
 But if you just want to install bim2sim and use trial and error technique go via
 ```


### PR DESCRIPTION
This moves the CI jobs for sphinx and pages deployment to our preconfigured jobs from EBC. We now use github pages instead GitLab pages which should improve the CI pipeline performance a bit and might also improve visibility of the repository for common search engines (google etc.)