### PR TITLE
593 switch source for heating and cooling profiles

### DIFF
--- a/bim2sim/sim_settings.py
+++ b/bim2sim/sim_settings.py
@@ -569,6 +569,15 @@ class BuildingSimSettings(BaseSimSettings):
                     "and usage conditions from UseConditions.json.",
         for_frontend=True
     )
+    setpoints_from_template = BooleanSetting(
+        default=False,
+        description="Use template heating and cooling profiles instead of "
+                    "setpoints from IFC. Defaults to False, i.e., "
+                    "use original data source. Set to True, "
+                    "if template-based values should be used instead.",
+        for_frontend=True
+    )
+
 
 class CFDSimSettings(BaseSimSettings):
     # todo make something useful

--- a/bim2sim/tasks/bps/enrich_use_cond.py
+++ b/bim2sim/tasks/bps/enrich_use_cond.py
@@ -38,6 +38,13 @@ class EnrichUseConditions(ITask):
                 orig_usage = tz.usage
                 tz.usage = usage
                 self.load_usage(tz)
+                # overwrite loaded heating and cooling profiles with
+                # template values if setpoints_from_template == True
+                if self.playground.sim_settings.setpoints_from_template:
+                    tz.heating_profile = \
+                        self.use_conditions[usage]['heating_profile']
+                    tz.cooling_profile = \
+                        self.use_conditions[usage]['cooling_profile']
                 self.enriched_tz.append(tz)
                 self.logger.info('Enrich ThermalZone from IfcSpace with '
                                  'original usage "%s" with usage "%s"',


### PR DESCRIPTION
Hotfix: Overwrite heating and cooling profiles with template based profiles, if the related new sim_setting is enabled. 