### PR TITLE
Fix startup logging errors

### DIFF
--- a/bim2sim/elements/aggregation/__init__.py
+++ b/bim2sim/elements/aggregation/__init__.py
@@ -33,8 +33,9 @@ class AggregationMixin:
     @classmethod
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
-        if ProductBased not in inspect.getmro(cls):
-            logger.error("%s only supports sub classes of ProductBased", cls)
+        if "Mixin" not in cls.__name__:
+            if ProductBased not in inspect.getmro(cls):
+                logger.error("%s only supports sub classes of ProductBased", cls)
 
     def calc_position(self):
         """Position based on first and last element"""

--- a/bim2sim/elements/aggregation/__init__.py
+++ b/bim2sim/elements/aggregation/__init__.py
@@ -34,14 +34,7 @@ class AggregationMixin:
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
         if ProductBased not in inspect.getmro(cls):
-            # raise AssertionError("%s only supports sub classes of ProductBased" % cls)
             logger.error("%s only supports sub classes of ProductBased", cls)
-
-        # TODO: this are only temporary checks
-        if hasattr(cls, 'ifc_type'):
-            logger.warning("Obsolete use of 'ifc_type' in %s" % cls)
-        if hasattr(cls, 'predefined_types'):
-            logger.warning("Obsolete use of 'predefined_types' in %s" % cls)
 
     def calc_position(self):
         """Position based on first and last element"""

--- a/bim2sim/elements/aggregation/__init__.py
+++ b/bim2sim/elements/aggregation/__init__.py
@@ -3,6 +3,7 @@ E.g. multiple thermal zones into one thermal zone
 """
 import logging
 from typing import Set, Sequence
+import inspect
 
 from bim2sim.elements.base_elements import ProductBased
 
@@ -32,7 +33,7 @@ class AggregationMixin:
     @classmethod
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
-        if ProductBased not in cls.__bases__:
+        if ProductBased not in inspect.getmro(cls):
             # raise AssertionError("%s only supports sub classes of ProductBased" % cls)
             logger.error("%s only supports sub classes of ProductBased", cls)
 

--- a/bim2sim/project.py
+++ b/bim2sim/project.py
@@ -381,7 +381,7 @@ class Project:
         # tear down existing handlers (just in case)
         self._teardown_logger()
 
-        thread_name = threading.Thread.getName(threading.current_thread())
+        thread_name = threading.current_thread().name
 
         # quality logger
         quality_logger = logging.getLogger('bim2sim.QualityReport')
@@ -407,7 +407,7 @@ class Project:
 
     def _update_logging_thread_filters(self):
         """Update thread filters to current thread."""
-        thread_name = threading.Thread.getName(threading.current_thread())
+        thread_name = threading.current_thread().name
         for thread_filter in self._log_thread_filters:
             thread_filter.thread_name = thread_name
 
@@ -420,7 +420,7 @@ class Project:
             set_formatter: if True, the user_handlers formatter is set
         """
         general_logger = logging.getLogger('bim2sim')
-        thread_name = threading.Thread.getName(threading.current_thread())
+        thread_name = threading.current_thread().name
 
         if self._user_logger_set:
             self._setup_logger()


### PR DESCRIPTION
This removes two logging errors/warnings when starting up bim2sim.

* `<class 'bim2sim.elements.aggregation.bps_aggregations.AggregatedThermalZone'> only supports sub classes of ProductBased`
this was triggered as not all base classes were checked but just the first level of base classes. 

* `Obsolete use of 'ifc_type' in <class 'bim2sim.elements.aggregation.bps_aggregations.AggregatedThermalZone'>`
*  this was just build into the code during some refactoring. `ifc_type` is now a cached property that every element in bim2sim has. So this error is missleading and removed.