### PR TITLE
use sprase solver and higher tolerance to improve sim speed

### DIFF
--- a/bim2sim/plugins/PluginTEASER/bim2sim_teaser/task/simulate_dymola_ebcpy.py
+++ b/bim2sim/plugins/PluginTEASER/bim2sim_teaser/task/simulate_dymola_ebcpy.py
@@ -41,7 +41,7 @@ class SimulateModelEBCPy(ITask):
                                 "stop_time": 3.1536e+07,
                                 "output_interval": 3600,
                                 "solver": "Cvode",
-                                "tolerance": 0.000001}
+                                "tolerance": 0.001}
             n_success = 0
             for n_sim, bldg_name in enumerate(bldg_names):
                 self.logger.info(f"Starting Simulating Process for model "

--- a/bim2sim/plugins/PluginTEASER/bim2sim_teaser/task/simulate_dymola_ebcpy.py
+++ b/bim2sim/plugins/PluginTEASER/bim2sim_teaser/task/simulate_dymola_ebcpy.py
@@ -39,7 +39,9 @@ class SimulateModelEBCPy(ITask):
 
             simulation_setup = {"start_time": 0,
                                 "stop_time": 3.1536e+07,
-                                "output_interval": 3600}
+                                "output_interval": 3600,
+                                "solver": "Cvode",
+                                "tolerance": 0.000001}
             n_success = 0
             for n_sim, bldg_name in enumerate(bldg_names):
                 self.logger.info(f"Starting Simulating Process for model "
@@ -65,7 +67,8 @@ class SimulateModelEBCPy(ITask):
                                     "are several possible reasons."
                                     " One could be a missing Dymola license.")
                 dym_api.set_sim_setup(sim_setup=simulation_setup)
-
+                # activate spare solver as TEASER models are mostly sparse
+                dym_api.dymola.ExecuteCommand("Advanced.SparseActivate=true")
                 teaser_mat_result_path = dym_api.simulate(
                     return_option="savepath"
                 )


### PR DESCRIPTION
This will improve the simulation speed of the dymola simulations in PluginTEASER. The slightly higher tolerance is acceptable compared to the simulation speed gain. 

Attached you find a screenshot of the changes due to sparse solver (blue) and to reduced tolerance (green)
![image](https://github.com/BIM2SIM/bim2sim/assets/27726960/761a5161-5469-44c7-8a57-2a0072a9eb1f)
