### PR TITLE
temp disable ProcessSlabsRoofs tasks as it creates faulty results

### DIFF
--- a/bim2sim/plugins/PluginEnergyPlus/bim2sim_energyplus/__init__.py
+++ b/bim2sim/plugins/PluginEnergyPlus/bim2sim_energyplus/__init__.py
@@ -18,7 +18,7 @@ class PluginEnergyPlus(Plugin):
         common.CreateElements,
         bps.CreateSpaceBoundaries,
         bps.FilterTZ,
-        bps.ProcessSlabsRoofs,
+        # bps.ProcessSlabsRoofs,
         common.BindStoreys,
         bps.EnrichUseConditions,
         bps.VerifyLayersMaterials,  # LOD.full

--- a/bim2sim/plugins/PluginTEASER/bim2sim_teaser/__init__.py
+++ b/bim2sim/plugins/PluginTEASER/bim2sim_teaser/__init__.py
@@ -26,7 +26,7 @@ class PluginTEASER(Plugin):
         common.CreateElements,
         bps.CreateSpaceBoundaries,
         bps.FilterTZ,
-        bps.ProcessSlabsRoofs,
+        # bps.ProcessSlabsRoofs,
         common.BindStoreys,
         bps.EnrichUseConditions,
         bps.VerifyLayersMaterials,

--- a/bim2sim/plugins/PluginTemplate/bim2sim_template/__init__.py
+++ b/bim2sim/plugins/PluginTemplate/bim2sim_template/__init__.py
@@ -18,7 +18,7 @@ class PluginTemplate(Plugin):
         common.CheckIfc,
         common.CreateElements,
         bps.FilterTZ,
-        bps.ProcessSlabsRoofs,
+        # bps.ProcessSlabsRoofs,
         bps.CreateSpaceBoundaries,
         bps.EnrichUseConditions,
         common.BindStoreys,

--- a/bim2sim/plugins/__init__.py
+++ b/bim2sim/plugins/__init__.py
@@ -67,7 +67,7 @@ class PluginBPSBase(Plugin):
         common.CheckIfc,
         common.create_elements,
         bps.CreateSpaceBoundaries,
-        bps.ProcessSlabsRoofs,
+        # bps.ProcessSlabsRoofs,
         bps.DisaggregationCreation,
         bps.CombineThermalZones
     ]


### PR DESCRIPTION
For further description see #628 
This does not solve the issue but just prevents further errors due to the faulty task.