### PR TITLE
Update .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,12 +1,11 @@
 stages:
-  - code_quality
-  - doc
-  - deploy
   - test
+  - doc
+  - code_quality
+  - deploy
   - build-env
   - build-env-plugins
   - build-tool
-  - visualize
 
 variables:
   # TODO variable inside variable seems not be working on our gitlab instance,


### PR DESCRIPTION
run tests first, this is needed so we have a coverage again. Currently the test stage runs after the deploy stage and so we can't deploy the results of the coverage run.