### PR TITLE
if pathsetting is set to default, even None is valid

### DIFF
--- a/bim2sim/sim_settings.py
+++ b/bim2sim/sim_settings.py
@@ -317,7 +317,7 @@ class PathSetting(Setting):
     def __set__(self, bound_simulation_settings, value):
         """This is the set function that sets the value in the simulation setting
         when calling sim_settings.<setting_name> = <value>"""
-        if not isinstance(value, Path):
+        if not isinstance(value, Path) and not value == self.default:
             if value:
                 try:
                     value = Path(value)
@@ -806,7 +806,6 @@ class TEASERSimSettings(BuildingSimSettings):
         },
         for_frontend=True
     )
-
 
 class EnergyPlusSimSettings(BuildingSimSettings):
     """Defines simulation settings for EnergyPlus Plugin.


### PR DESCRIPTION
With this changes a `PathSetting`  that as a default value of None is still valid.

Anyway, if the `PathSetting` is marked as `mandatory` a default of None  which was not overwritten will lead to an error when the ,when`run_project()` is called and therefore `check_mandatory()` runs. This than looks like this:

```
Attempted to run project. Simulation setting weather_file_path is not specified, but is marked as mandatory. Please configure weather_file_path before running your project.
```

This behavior is much cleaner, because a `default=None` for a `PathSetting` won't lead to an error during project creation.