### PR TITLE
add option to add central ahu via sim settings

### DIFF
--- a/bim2sim/elements/bps_elements.py
+++ b/bim2sim/elements/bps_elements.py
@@ -1813,6 +1813,15 @@ class Building(BPSProduct):
                 avg_height = storey_height_sum / len(self.storeys)
         return avg_height
 
+    def _check_tz_ahu(self, name):
+        """Check if any TZs have AHU, then the building has one as well."""
+        with_ahu = False
+        for tz in self.thermal_zones:
+            if tz.with_ahu:
+                with_ahu = True
+                break
+        return with_ahu
+
     bldg_name = attribute.Attribute(
         functions=[_get_building_name],
     )
@@ -1838,6 +1847,23 @@ class Building(BPSProduct):
     avg_storey_height = attribute.Attribute(
         unit=ureg.meter,
         functions=[_get_avg_storey_height]
+    )
+    with_ahu = attribute.Attribute(
+        functions=[_check_tz_ahu]
+    )
+    # TODO Due to #722 the following values needs to be set via sim_setting,
+    #  because we don't allow boolean attributes for now.
+    ahu_heating = attribute.Attribute(
+    )
+    ahu_cooling = attribute.Attribute(
+    )
+    ahu_dehumidification = attribute.Attribute(
+    )
+    ahu_humidification = attribute.Attribute(
+    )
+    ahu_heat_recovery = attribute.Attribute(
+    )
+    ahu_heat_recovery_efficiency = attribute.Attribute(
     )
 
 

--- a/bim2sim/plugins/PluginTEASER/bim2sim_teaser/examples/e2_complex_project_teaser.py
+++ b/bim2sim/plugins/PluginTEASER/bim2sim_teaser/examples/e2_complex_project_teaser.py
@@ -2,7 +2,7 @@ import tempfile
 from pathlib import Path
 
 import bim2sim
-from bim2sim import Project
+from bim2sim import Project, ConsoleDecisionHandler
 from bim2sim.kernel.decision.decisionhandler import DebugDecisionHandler
 from bim2sim.kernel.log import default_logging_setup
 from bim2sim.utilities.types import IFCDomain, LOD, ZoningCriteria
@@ -46,6 +46,11 @@ def run_example_complex_building_teaser():
     # use cooling
     project.sim_settings.cooling = True
     project.sim_settings.setpoints_from_template = True
+
+    project.sim_settings.overwrite_ahu_by_settings = True
+    project.sim_settings.ahu_heating = True
+    project.sim_settings.ahu_cooling = True
+    project.sim_settings.ahu_heat_recovery = True
 
     # overwrite existing layer structures and materials based on templates
     project.sim_settings.layers_and_materials = LOD.low
@@ -99,6 +104,7 @@ def run_example_complex_building_teaser():
     answers = (space_boundary_genenerator,
                *handle_proxies,
                construction_year)
+    # handler = ConsoleDecisionHandler()
     handler = DebugDecisionHandler(answers)
     handler.handle(project.run())
 

--- a/bim2sim/plugins/PluginTEASER/bim2sim_teaser/models/__init__.py
+++ b/bim2sim/plugins/PluginTEASER/bim2sim_teaser/models/__init__.py
@@ -24,6 +24,8 @@ from teaser.logic.buildingobjects.thermalzone import \
     ThermalZone as ThermalZone_Teaser
 from teaser.logic.buildingobjects.useconditions import \
     UseConditions as UseConditions_Teaser
+from teaser.logic.buildingobjects.buildingsystems.buildingahu import \
+    BuildingAHU as BuildingAHU_Teaser
 
 from bim2sim.elements.aggregation.bps_aggregations import AggregatedThermalZone
 from bim2sim.elements import bps_elements as bps
@@ -44,6 +46,8 @@ class Building(TEASER, Building_Teaser):
         TEASER.__init__(self, bim2sim_element)
         self.used_library_calc = "AixLib"
         self.add_thermal_zones_to_building()
+        if bim2sim_element.with_ahu:
+            self.central_ahu = BuildingAHU(element=bim2sim_element, parent=self)
 
     def add_thermal_zones_to_building(self):
         for tz in self.element.thermal_zones:
@@ -62,6 +66,7 @@ class Building(TEASER, Building_Teaser):
                            self.check_numeric(
                                min_value=1 * ureg.meter),
                            "height_of_floors")
+        self.request_param("with_ahu")
 
 
 class ThermalZone(TEASER, ThermalZone_Teaser):
@@ -91,6 +96,39 @@ class ThermalZone(TEASER, ThermalZone_Teaser):
         self.request_param("net_volume",
                            None,
                            "volume")
+
+
+class BuildingAHU(TEASER, BuildingAHU_Teaser):
+    represents = []
+
+    def __init__(self, element, parent):
+        BuildingAHU_Teaser.__init__(self, parent=parent)
+        self.overwrite_teaser_defaults()
+        TEASER.__init__(self, element)
+
+    def overwrite_teaser_defaults(self):
+        """Overwrites default BuildingAHU values from TEASER
+
+        This is required as TEASER sets defaults for e.g. the AHU setup and in
+        enrichment we only enrich not-existing values. Without setting the
+        defaults back to None would lead to errors.
+        """
+        self.heating = None
+        self.cooling = None
+        self.dehumidification = None
+        self.humidification = None
+        self.heat_recovery = None
+        self.efficiency_recovery = None
+
+    def request_params(self):
+        self.request_param("ahu_heating", export_name="heating")
+        self.request_param("ahu_cooling", export_name="cooling")
+        self.request_param("ahu_dehumidification",
+                           export_name="dehumidification")
+        self.request_param("ahu_humidification", export_name="humidification")
+        self.request_param("ahu_heat_recovery", export_name="heat_recovery")
+        self.request_param("ahu_heat_recovery_efficiency",
+                           export_name="efficiency_recovery")
 
 
 class UseConditions(TEASER, UseConditions_Teaser):

--- a/bim2sim/sim_settings.py
+++ b/bim2sim/sim_settings.py
@@ -803,10 +803,55 @@ class BuildingSimSettings(BaseSimSettings):
                     "set_run_period==True for activation.",
         for_frontend=True
     )
-    plot_singe_zone_guid=ChoiceSetting(
+    plot_singe_zone_guid = ChoiceSetting(
         default='',
         choices={'': "Skip"},
         description="Choose the GlobalId of the IfcSpace for which results "
                     "should be plotted.",
         any_string=True
+    )
+    # Due to issue #722 this is currently the only way to set AHU values.
+    overwrite_ahu_by_settings = BooleanSetting(
+        default=True,
+        description='Overwrite central AHU settings with the following '
+                    'settings.',
+    )
+    ahu_heating = BooleanSetting(
+        default=False,
+        description="Choose if the central AHU should provide heating. "
+                    "Set overwrite_ahu_by_settings to True, "
+                    "otherwise this has no effect. "
+    )
+    ahu_cooling = BooleanSetting(
+        default=False,
+        description="Choose if the central AHU should provide cooling."
+                    "Set overwrite_ahu_by_settings to True, "
+                    "otherwise this has no effect. "
+    )
+    ahu_dehumidification = BooleanSetting(
+        default=False,
+        description="Choose if the central AHU should provide "
+                    "dehumidification."
+                    "Set overwrite_ahu_by_settings to True, "
+                    "otherwise this has no effect. "
+    )
+    ahu_humidification = BooleanSetting(
+        default=False,
+        description="Choose if the central AHU should provide humidification."
+                    "Set overwrite_ahu_by_settings to True, "
+                    "otherwise this has no effect. "
+    )
+    ahu_heat_recovery = BooleanSetting(
+        default=False,
+        description="Choose if the central AHU should zuse heat recovery."
+                    "Set overwrite_ahu_by_settings to True, "
+                    "otherwise this has no effect. "
+    )
+    ahu_heat_recovery_efficiency = NumberSetting(
+        default=0.65,
+        min_value= 0.5,
+        max_value=0.99,
+        description="Choose the heat recovery efficiency of the central AHU."
+                    "Set overwrite_ahu_by_settings to True, "
+                    "otherwise this has no effect. "
     )

--- a/bim2sim/tasks/bps/enrich_use_cond.py
+++ b/bim2sim/tasks/bps/enrich_use_cond.py
@@ -5,6 +5,7 @@ from bim2sim.elements.bps_elements import ThermalZone
 from bim2sim.tasks.base import ITask
 from bim2sim.utilities.common_functions import get_use_conditions_dict, \
     get_pattern_usage, wildcard_match, filter_elements
+from bim2sim.utilities.types import AttributeDataSource
 
 
 class EnrichUseConditions(ITask):
@@ -19,7 +20,7 @@ class EnrichUseConditions(ITask):
         self.use_conditions = {}
 
     def run(self, elements: dict):
-        """Enriches Use Conditions of thermal zones.
+        """Enriches Use Conditions of thermal zones and central AHU settings.
 
         Enrichment data in the files commonUsages.json and UseConditions.json
         is taken from TEASER. The underlying data comes from DIN 18599-10 and
@@ -57,6 +58,27 @@ class EnrichUseConditions(ITask):
                 self.logger.info('Enrich ThermalZone from IfcSpace with '
                                  'original usage "%s" with usage "%s"',
                                  orig_usage, usage)
+        building_elements = filter_elements(elements, 'Building')
+        if self.playground.sim_settings.overwrite_ahu_by_settings:
+            for building in building_elements:
+                building.ahu_heating = (
+                    self.playground.sim_settings.ahu_heating,
+                    AttributeDataSource.enrichment)
+                building.ahu_cooling = (
+                    self.playground.sim_settings.ahu_cooling,
+                    AttributeDataSource.enrichment)
+                building.ahu_humidification = (
+                    self.playground.sim_settings.ahu_humidification,
+                    AttributeDataSource.enrichment)
+                building.ahu_dehumidification = (
+                    self.playground.sim_settings.ahu_dehumidification,
+                    AttributeDataSource.enrichment)
+                building.ahu_heat_recovery = (
+                    self.playground.sim_settings.ahu_heat_recovery,
+                    AttributeDataSource.enrichment)
+                building.ahu_heat_recovery_efficiency = (
+                    self.playground.sim_settings.ahu_heat_recovery_efficiency,
+                    AttributeDataSource.enrichment)
 
     @staticmethod
     def set_heating_cooling(tz_elements:dict , sim_settings):

--- a/docs/source/simulation-guide.md
+++ b/docs/source/simulation-guide.md
@@ -6,5 +6,6 @@
    :maxdepth: 2
 
    simulation-guide/simulation-types.md
+   simulation-guide/plugin-guides/teaser.md
 
 ```

--- a/docs/source/simulation-guide/plugin-guides/teaser.md
+++ b/docs/source/simulation-guide/plugin-guides/teaser.md
@@ -8,50 +8,50 @@ the AHU uses heating, cooling, dehumidification etc. and what air profiles are
 used, we are using the defaults from TEASER for most of the values.
 For some values we allow configuration directly via the following `sim_settings`:
 ```python
-    overwrite_ahu_by_settings = BooleanSetting(
-        default=True,
-        description='Overwrite central AHU settings with the following '
-                    'settings.',
-    )
-    ahu_heating = BooleanSetting(
-        default=False,
-        description="Choose if the central AHU should provide heating. "
-                    "Set overwrite_ahu_by_settings to True, "
-                    "otherwise this has no effect. "
-    )
-    ahu_cooling = BooleanSetting(
-        default=False,
-        description="Choose if the central AHU should provide cooling."
-                    "Set overwrite_ahu_by_settings to True, "
-                    "otherwise this has no effect. "
-    )
-    ahu_dehumidification = BooleanSetting(
-        default=False,
-        description="Choose if the central AHU should provide "
-                    "dehumidification."
-                    "Set overwrite_ahu_by_settings to True, "
-                    "otherwise this has no effect. "
-    )
-    ahu_humidification = BooleanSetting(
-        default=False,
-        description="Choose if the central AHU should provide humidification."
-                    "Set overwrite_ahu_by_settings to True, "
-                    "otherwise this has no effect. "
-    )
-    ahu_heat_recovery = BooleanSetting(
-        default=False,
-        description="Choose if the central AHU should zuse heat recovery."
-                    "Set overwrite_ahu_by_settings to True, "
-                    "otherwise this has no effect. "
-    )
-    ahu_heat_recovery_efficiency = NumberSetting(
-        default=0.65,
-        min_value= 0.5,
-        max_value=0.99,
-        description="Choose the heat recovery efficiency of the central AHU."
-                    "Set overwrite_ahu_by_settings to True, "
-                    "otherwise this has no effect. "
-    )
+overwrite_ahu_by_settings = BooleanSetting(
+    default=True,
+    description='Overwrite central AHU settings with the following '
+                'settings.',
+)
+ahu_heating = BooleanSetting(
+    default=False,
+    description="Choose if the central AHU should provide heating. "
+                "Set overwrite_ahu_by_settings to True, "
+                "otherwise this has no effect. "
+)
+ahu_cooling = BooleanSetting(
+    default=False,
+    description="Choose if the central AHU should provide cooling."
+                "Set overwrite_ahu_by_settings to True, "
+                "otherwise this has no effect. "
+)
+ahu_dehumidification = BooleanSetting(
+    default=False,
+    description="Choose if the central AHU should provide "
+                "dehumidification."
+                "Set overwrite_ahu_by_settings to True, "
+                "otherwise this has no effect. "
+)
+ahu_humidification = BooleanSetting(
+    default=False,
+    description="Choose if the central AHU should provide humidification."
+                "Set overwrite_ahu_by_settings to True, "
+                "otherwise this has no effect. "
+)
+ahu_heat_recovery = BooleanSetting(
+    default=False,
+    description="Choose if the central AHU should zuse heat recovery."
+                "Set overwrite_ahu_by_settings to True, "
+                "otherwise this has no effect. "
+)
+ahu_heat_recovery_efficiency = NumberSetting(
+    default=0.65,
+    min_value= 0.5,
+    max_value=0.99,
+    description="Choose the heat recovery efficiency of the central AHU."
+                "Set overwrite_ahu_by_settings to True, "
+                "otherwise this has no effect. "
+)
 ```
 You can overwrite all other values by using TEASER after you created the TEASER
 project with `bim2sim` if wanted. 

--- a/docs/source/simulation-guide/plugin-guides/teaser.md
+++ b/docs/source/simulation-guide/plugin-guides/teaser.md
@@ -5,5 +5,53 @@ TEASER simulates an AHU based
 on [this Modelica model from AixLib](https://github.com/RWTH-EBC/AixLib/blob/main/AixLib/Airflow/AirHandlingUnit/AHU.mo).
 As the IFC can't contain specific information for the AHU currently, like if
 the AHU uses heating, cooling, dehumidification etc. and what air profiles are
-used, we are using the defaults from TEASER. You can overwrite these values by
-using TEASER after you created the TEASER project with `bim2sim` if wanted. 
+used, we are using the defaults from TEASER for most of the values.
+For some values we allow configuration directly via the following `sim_settings`:
+```python
+    overwrite_ahu_by_settings = BooleanSetting(
+        default=True,
+        description='Overwrite central AHU settings with the following '
+                    'settings.',
+    )
+    ahu_heating = BooleanSetting(
+        default=False,
+        description="Choose if the central AHU should provide heating. "
+                    "Set overwrite_ahu_by_settings to True, "
+                    "otherwise this has no effect. "
+    )
+    ahu_cooling = BooleanSetting(
+        default=False,
+        description="Choose if the central AHU should provide cooling."
+                    "Set overwrite_ahu_by_settings to True, "
+                    "otherwise this has no effect. "
+    )
+    ahu_dehumidification = BooleanSetting(
+        default=False,
+        description="Choose if the central AHU should provide "
+                    "dehumidification."
+                    "Set overwrite_ahu_by_settings to True, "
+                    "otherwise this has no effect. "
+    )
+    ahu_humidification = BooleanSetting(
+        default=False,
+        description="Choose if the central AHU should provide humidification."
+                    "Set overwrite_ahu_by_settings to True, "
+                    "otherwise this has no effect. "
+    )
+    ahu_heat_recovery = BooleanSetting(
+        default=False,
+        description="Choose if the central AHU should zuse heat recovery."
+                    "Set overwrite_ahu_by_settings to True, "
+                    "otherwise this has no effect. "
+    )
+    ahu_heat_recovery_efficiency = NumberSetting(
+        default=0.65,
+        min_value= 0.5,
+        max_value=0.99,
+        description="Choose the heat recovery efficiency of the central AHU."
+                    "Set overwrite_ahu_by_settings to True, "
+                    "otherwise this has no effect. "
+    )
+```
+You can overwrite all other values by using TEASER after you created the TEASER
+project with `bim2sim` if wanted. 

--- a/docs/source/simulation-guide/plugin-guides/teaser.md
+++ b/docs/source/simulation-guide/plugin-guides/teaser.md
@@ -1,0 +1,9 @@
+# TEASER Simulation Guide
+
+## AHU
+TEASER simulates an AHU based
+on [this Modelica model from AixLib](https://github.com/RWTH-EBC/AixLib/blob/main/AixLib/Airflow/AirHandlingUnit/AHU.mo).
+As the IFC can't contain specific information for the AHU currently, like if
+the AHU uses heating, cooling, dehumidification etc. and what air profiles are
+used, we are using the defaults from TEASER. You can overwrite these values by
+using TEASER after you created the TEASER project with `bim2sim` if wanted. 


### PR DESCRIPTION
This adds the option to activate and configure a central ahu. The export is working for TEASER.
Due to #722 this is currently only possible via `sim_settings`. I documented this in the TEASER simulation guide (which was just started).

I added some parametrization of the central AHU for the `e2_complex_project_teaser.py`
