### PR TITLE
use BuildingSimSettings no as possible and update docs

### DIFF
--- a/bim2sim/examples/e1_template_plugin.py
+++ b/bim2sim/examples/e1_template_plugin.py
@@ -12,7 +12,7 @@ from bim2sim.elements.base_elements import Material
 
 
 def run_simple_project():
-    """Run the building simulation with teaser as backend in interactive mode.
+    """Run a bim2sim project with the TemplatePlugin.
     
     This example will show how to set up a project based on an IFC file,
     how to create bim2sim elements based on the existing IFC data with all
@@ -76,19 +76,6 @@ def run_simple_project():
     project.sim_settings.weather_file_path = (
             Path(bim2sim.__file__).parent.parent /
             'test/resources/weather_files/DEU_NW_Aachen.105010_TMYx.mos')
-
-    # Assign relevant elements
-    # TODO this is currently not true, as we need to use TEASERTemplate,
-    #  we need to solve #511 and #583 first
-    # The template plugin uses the BaseSimSettings which don't have any
-    # relevant elements defined. This means without overwriting the
-    # `relevant_elements` setting, no bim2sim elements will be created.
-    # Let's assign all `bps_elements` and the `Material` element. This way
-    # the IFC will be searched for all IFC entities that should be mapped into
-    # the classes defined in `bps_elements` and in the class `Material`.
-    # For further information about the elements structure and the mapping
-    # procedure please read the `elements` documentation
-    project.sim_settings.relevant_elements = {*bps_elements.items, Material}
 
     # Assign the enrichment for use conditions of thermal zones.
 

--- a/bim2sim/plugins/PluginTemplate/bim2sim_template/__init__.py
+++ b/bim2sim/plugins/PluginTemplate/bim2sim_template/__init__.py
@@ -4,15 +4,12 @@ Holds a plugin with only base tasks mostly for demonstration.
 """
 from bim2sim.plugins import Plugin
 from bim2sim.tasks import common, bps
-from bim2sim.plugins.PluginTEASER.bim2sim_teaser.sim_settings import \
-    TEASERSimSettings
+from bim2sim.sim_settings import BuildingSimSettings
 
 
 class PluginTemplate(Plugin):
     name = 'Template'
-    # TODO BuildingSimSetting don't work due to issues with #511 and #583
-    sim_settings = TEASERSimSettings
-    # sim_settings = BuildingSimSettings
+    sim_settings = BuildingSimSettings
     default_tasks = [
         common.LoadIFC,
         common.CheckIfc,


### PR DESCRIPTION
With the `sim_settings` now split up again into plugins I was able to update the PluginTemplate to not use TEASERSimSettings anymore.