### PR TITLE
fix ifcopenshell version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
 ]
 dependencies = [
-    "ifcopenshell>=0.7.0",
+    "ifcopenshell==0.7.0.240627",
     "docopt==0.6.2",
     "numpy==1.26.0",
     "pandas==2.1.3",


### PR DESCRIPTION
IfcOpenShell was updated to v0.8.0 but this leads to some issues with the geometry settings, e.g. see here: https://github.com/IfcOpenShell/IfcOpenShell/issues/4847


For now, we just fix the version to "ifcopenshell==0.7.0.240627"