### PR TITLE
Enable use of new custom usages

### DIFF
--- a/bim2sim/utilities/common_functions.py
+++ b/bim2sim/utilities/common_functions.py
@@ -162,6 +162,9 @@ def combine_usages(common_usages, custom_usages) -> dict:
                     raise TypeError("custom usages must be a list")
             if key in usages.keys():
                 usages[key]["custom"] = value
+            else:
+                usages[key]["custom"] = value
+                usages[key]["common"] = []
     return usages
 
 


### PR DESCRIPTION
If you want to add new custom usages, which have not been part of the default common usages, these new custom usages cannot be evaluated.


