### PR TITLE
Fix 'unknown field Zone_or_ZoneList_Name' exception when running BPS with EnergyPlus plugin

### DIFF
--- a/bim2sim/plugins/PluginEnergyPlus/bim2sim_energyplus/task/ep_create_idf.py
+++ b/bim2sim/plugins/PluginEnergyPlus/bim2sim_energyplus/task/ep_create_idf.py
@@ -176,14 +176,16 @@ class CreateIdf(ITask):
                 Volume=volume
             )
             self.set_heating_and_cooling(idf, zone_name=zone.Name, space=space)
-            self.set_infiltration(sim_settings, idf, name=zone.Name, zone_name=zone.Name,
-                                  space=space)
+            self.set_infiltration(
+                idf, name=zone.Name, zone_name=zone.Name, space=space,
+                ep_version=sim_settings.ep_version)
             if (not self.playground.sim_settings.cooling and
                     self.playground.sim_settings.add_natural_ventilation):
-                self.set_natural_ventilation(sim_settings, idf, name=zone.Name,
-                                             zone_name=zone.Name, space=space)
-            self.set_people(sim_settings, idf, name=zone.Name, zone_name=zone.Name,
-                            space=space)
+                self.set_natural_ventilation(
+                    idf, name=zone.Name, zone_name=zone.Name, space=space,
+                    ep_version=sim_settings.ep_version)
+            self.set_people(sim_settings, idf, name=zone.Name,
+                            zone_name=zone.Name, space=space)
             self.set_equipment(sim_settings, idf, name=zone.Name,
                                zone_name=zone.Name, space=space)
             self.set_lights(sim_settings, idf, name=zone.Name, zone_name=zone.Name,
@@ -728,8 +730,9 @@ class CreateIdf(ITask):
             )
 
     @staticmethod
-    def set_infiltration(sim_settings: EnergyPlusSimSettings, idf: IDF, name: str, zone_name: str,
-                         space: ThermalZone):
+    def set_infiltration(idf: IDF,
+                         name: str, zone_name: str,
+                         space: ThermalZone, ep_version: str):
         """Set infiltration rate.
 
         This function sets the infiltration rate per space based on the
@@ -741,8 +744,9 @@ class CreateIdf(ITask):
             name: name of the new people idf object
             zone_name: name of zone or zone_list
             space: ThermalZone instance
+            ep_version: Used version of EnergyPlus
         """
-        if sim_settings.ep_version in ["9-2-0", "9-4-0"]:
+        if ep_version in ["9-2-0", "9-4-0"]:
             idf.newidfobject(
                 "ZONEINFILTRATION:DESIGNFLOWRATE",
                 Name=name,
@@ -762,8 +766,8 @@ class CreateIdf(ITask):
             )
 
     @staticmethod
-    def set_natural_ventilation(sim_settings: EnergyPlusSimSettings, idf: IDF, name: str, zone_name: str,
-                                space: ThermalZone):
+    def set_natural_ventilation(idf: IDF, name: str, zone_name: str,
+                                space: ThermalZone, ep_version):
         """Set natural ventilation.
 
         This function sets the natural ventilation per space based on the
@@ -777,8 +781,10 @@ class CreateIdf(ITask):
             name: name of the new people idf object
             zone_name: name of zone or zone_list
             space: ThermalZone instance
+            ep_version: Used version of EnergyPlus
+
         """
-        if sim_settings.ep_version in ["9-2-0", "9-4-0"]:
+        if ep_version in ["9-2-0", "9-4-0"]:
             idf.newidfobject(
                 "ZONEVENTILATION:DESIGNFLOWRATE",
                 Name=name + '_winter',

--- a/bim2sim/plugins/PluginEnergyPlus/bim2sim_energyplus/task/ep_create_idf.py
+++ b/bim2sim/plugins/PluginEnergyPlus/bim2sim_energyplus/task/ep_create_idf.py
@@ -180,7 +180,7 @@ class CreateIdf(ITask):
                                   space=space)
             if (not self.playground.sim_settings.cooling and
                     self.playground.sim_settings.add_natural_ventilation):
-                self.set_natural_ventilation(idf, sim_settings, name=zone.Name,
+                self.set_natural_ventilation(sim_settings, idf, name=zone.Name,
                                              zone_name=zone.Name, space=space)
             self.set_people(sim_settings, idf, name=zone.Name, zone_name=zone.Name,
                             space=space)

--- a/bim2sim/plugins/PluginEnergyPlus/bim2sim_energyplus/task/ep_create_idf.py
+++ b/bim2sim/plugins/PluginEnergyPlus/bim2sim_energyplus/task/ep_create_idf.py
@@ -176,7 +176,7 @@ class CreateIdf(ITask):
                 Volume=volume
             )
             self.set_heating_and_cooling(idf, zone_name=zone.Name, space=space)
-            self.set_infiltration(idf, name=zone.Name, zone_name=zone.Name,
+            self.set_infiltration(sim_settings, idf, name=zone.Name, zone_name=zone.Name,
                                   space=space)
             if (not self.playground.sim_settings.cooling and
                     self.playground.sim_settings.add_natural_ventilation):
@@ -728,7 +728,7 @@ class CreateIdf(ITask):
             )
 
     @staticmethod
-    def set_infiltration(idf: IDF, name: str, zone_name: str,
+    def set_infiltration(sim_settings: EnergyPlusSimSettings, idf: IDF, name: str, zone_name: str,
                          space: ThermalZone):
         """Set infiltration rate.
 
@@ -742,14 +742,24 @@ class CreateIdf(ITask):
             zone_name: name of zone or zone_list
             space: ThermalZone instance
         """
-        idf.newidfobject(
-            "ZONEINFILTRATION:DESIGNFLOWRATE",
-            Name=name,
-            Zone_or_ZoneList_Name=zone_name,
-            Schedule_Name="Continuous",
-            Design_Flow_Rate_Calculation_Method="AirChanges/Hour",
-            Air_Changes_per_Hour=space.infiltration_rate
-        )
+        if sim_settings.ep_version in ["9-2-0", "9-4-0"]:
+            idf.newidfobject(
+                "ZONEINFILTRATION:DESIGNFLOWRATE",
+                Name=name,
+                Zone_or_ZoneList_Name=zone_name,
+                Schedule_Name="Continuous",
+                Design_Flow_Rate_Calculation_Method="AirChanges/Hour",
+                Air_Changes_per_Hour=space.infiltration_rate
+            )
+        else:
+            idf.newidfobject(
+                "ZONEINFILTRATION:DESIGNFLOWRATE",
+                Name=name,
+                Zone_or_ZoneList_or_Space_or_SpaceList_Name=zone_name,
+                Schedule_Name="Continuous",
+                Design_Flow_Rate_Calculation_Method="AirChanges/Hour",
+                Air_Changes_per_Hour=space.infiltration_rate
+            )
 
     @staticmethod
     def set_natural_ventilation(idf: IDF, name: str, zone_name: str,


### PR DESCRIPTION
When running the [Simple Project EnergyPlus example](https://github.com/BIM2SIM/bim2sim/blob/development/bim2sim/plugins/PluginEnergyPlus/bim2sim_energyplus/examples/e1_simple_project_energyplus.py) with current EP version (24.2.0) the 
`eppy.bunch_subclass.BadEPFieldError: unknown field Zone_or_ZoneList_Name` exception was thrown due to missing case distinction in some places.