### PR TITLE
add serialization functionality for TEASER

### DIFF
--- a/bim2sim/plugins/PluginTEASER/bim2sim_teaser/__init__.py
+++ b/bim2sim/plugins/PluginTEASER/bim2sim_teaser/__init__.py
@@ -36,6 +36,7 @@ class PluginTEASER(Plugin):
         common.Weather,
         LoadLibrariesTEASER,
         teaser_task.CreateTEASER,
+        teaser_task.SerializeTEASER,
         common.SerializeElements,
         teaser_task.ExportTEASER,
         teaser_task.SimulateModelEBCPy,

--- a/bim2sim/plugins/PluginTEASER/bim2sim_teaser/examples/e5_serialize_teaser_prj.py
+++ b/bim2sim/plugins/PluginTEASER/bim2sim_teaser/examples/e5_serialize_teaser_prj.py
@@ -1,0 +1,119 @@
+import tempfile
+from pathlib import Path
+
+import bim2sim
+from bim2sim import Project, run_project, ConsoleDecisionHandler
+from bim2sim.kernel.decision.decisionhandler import DebugDecisionHandler
+from bim2sim.kernel.log import default_logging_setup
+from bim2sim.tasks import common, bps
+from bim2sim.utilities.common_functions import download_library
+from bim2sim.utilities.types import IFCDomain, LOD, ZoningCriteria
+from bim2sim.plugins.PluginTEASER.bim2sim_teaser import PluginTEASER, \
+    LoadLibrariesTEASER
+import bim2sim.plugins.PluginTEASER.bim2sim_teaser.task as teaser_task
+
+
+def run_serialize_teaser_project_example():
+    """Serialize a TEASER Project for further use."""
+    default_logging_setup()
+    # Create the default logging to for quality log and bim2sim main log
+    # (see logging documentation for more information)
+    project_path = Path(
+        tempfile.TemporaryDirectory(prefix='bim2sim_example1').name)
+
+    # Set the ifc path to use and define which domain the IFC belongs to
+    ifc_paths = {
+        IFCDomain.arch:
+            Path(bim2sim.__file__).parent.parent /
+            'test/resources/arch/ifc/AC20-Institute-Var-2.ifc',
+    }
+    # Create a project including the folder structure for the project with
+    # teaser as backend and no specified workflow (default workflow is taken)
+    project = Project.create(project_path, ifc_paths, 'teaser')
+
+    # specify simulation settings (please have a look at the documentation of
+    # all under concepts/sim_settings
+    # combine spaces to thermal zones based on their usage
+
+
+
+    project.sim_settings.zoning_setup = LOD.medium
+    project.sim_settings.zoning_criteria = ZoningCriteria.usage
+    # use cooling
+    project.sim_settings.cooling = False
+    project.sim_settings.setpoints_from_template = True
+
+    project.sim_settings.overwrite_ahu_by_settings = True
+    project.sim_settings.ahu_heating = True
+    project.sim_settings.ahu_cooling = True
+    project.sim_settings.ahu_heat_recovery = True
+
+    # overwrite existing layer structures and materials based on templates
+    project.sim_settings.layers_and_materials = LOD.low
+    # specify templates for the layer and material overwrite
+    project.sim_settings.construction_class_walls = 'heavy'
+    project.sim_settings.construction_class_windows = \
+        'Alu- oder Stahlfenster, Waermeschutzverglasung, zweifach'
+
+    # set weather file data
+    project.sim_settings.weather_file_path = (
+            Path(bim2sim.__file__).parent.parent /
+            'test/resources/weather_files/DEU_NW_Aachen.105010_TMYx.mos')
+    # Run a simulation directly with dymola after model creation
+    project.sim_settings.dymola_simulation = True
+    # Make sure that AixLib modelica library exist on machine by cloning it and
+    #  setting the path of it as a sim_setting
+    repo_url = "https://github.com/RWTH-EBC/AixLib.git"
+    branch_name = "main"
+    repo_name = "AixLib"
+    path_aixlib = (
+            Path(bim2sim.__file__).parent.parent / "local" / f"library_{repo_name}")
+    download_library(repo_url, branch_name, path_aixlib)
+    project.sim_settings.path_aixlib = path_aixlib / repo_name / 'package.mo'
+
+    # Select results to output:
+    project.sim_settings.sim_results = [
+        "heat_demand_total", "cool_demand_total",
+        "heat_demand_rooms", "cool_demand_rooms",
+        "heat_energy_total", "cool_energy_total",
+        "heat_energy_rooms", "cool_energy_rooms",
+        "operative_temp_rooms", "air_temp_rooms", "air_temp_out",
+        "internal_gains_machines_rooms", "internal_gains_persons_rooms",
+        "internal_gains_lights_rooms",
+        "heat_set_rooms",
+        "cool_set_rooms"
+    ]
+    project.sim_settings.prj_custom_usages = (Path(
+        bim2sim.__file__).parent.parent /
+            "test/resources/arch/custom_usages/"
+            "customUsagesAC20-Institute-Var-2_with_SB-1-0.json")
+    # create plots based on the results after simulation
+    project.sim_settings.create_plots = True
+    project.plugin_cls.default_tasks = [
+        common.LoadIFC,
+        common.CreateElementsOnIfcTypes,
+        bps.CreateSpaceBoundaries,
+        bps.AddSpaceBoundaries2B,
+        bps.CorrectSpaceBoundaries,
+        common.CreateRelations,
+        bps.DisaggregationCreationAndTypeCheck,
+        bps.EnrichMaterial,
+        bps.EnrichUseConditions,
+        bps.CombineThermalZones,
+        common.Weather,
+        LoadLibrariesTEASER,
+        teaser_task.CreateTEASER,
+        teaser_task.SerializeTEASER,
+    ]
+    answers = (2015,)
+    handler = DebugDecisionHandler(answers)
+    handler.handle(project.run())
+
+    # return the export path and the path of the serialized project json file
+    return (project.paths.export,
+            project.paths.export /
+            f"TEASER/serialized_teaser/{project.name}.json")
+
+
+if __name__ == '__main__':
+    run_serialize_teaser_project_example()

--- a/bim2sim/plugins/PluginTEASER/bim2sim_teaser/examples/e6_load_serialized_teaser_prj.py
+++ b/bim2sim/plugins/PluginTEASER/bim2sim_teaser/examples/e6_load_serialized_teaser_prj.py
@@ -5,7 +5,7 @@ from bim2sim_teaser.task import CreateTEASER
 from e5_serialize_teaser_prj import run_serialize_teaser_project_example
 
 
-def example_load():
+def load_serialized_teaser_project():
     """This function demonstrates different loading options of TEASER"""
 
     # In example e4_save we saved two TEASER projects using `*.teaserjson` and
@@ -78,6 +78,5 @@ def example_load():
 
 
 if __name__ == "__main__":
-    example_load()
+    load_serialized_teaser_project()
 
-    print("Example 5: That's it! :)")

--- a/bim2sim/plugins/PluginTEASER/bim2sim_teaser/examples/e6_load_serialized_teaser_prj.py
+++ b/bim2sim/plugins/PluginTEASER/bim2sim_teaser/examples/e6_load_serialized_teaser_prj.py
@@ -12,11 +12,6 @@ def example_load():
     # Python package pickle. This example shows how to import these
     # information into your python environment again.
 
-    # To load data from `*.teaserjson` we can use a simple API function. So
-    # first we need to instantiate our API (similar to example
-    # e1_generate_archetype). The json file is called
-    # `ArchetypeExample.teaserjson` and saved in the default path. You need to
-    # run e4 first before you can load this example file.
     prj_export_path, prj_json_path = run_serialize_teaser_project_example()
     prj = Project()
 

--- a/bim2sim/plugins/PluginTEASER/bim2sim_teaser/examples/e6_load_serialized_teaser_prj.py
+++ b/bim2sim/plugins/PluginTEASER/bim2sim_teaser/examples/e6_load_serialized_teaser_prj.py
@@ -7,11 +7,6 @@ from e5_serialize_teaser_prj import run_serialize_teaser_project_example
 
 def load_serialized_teaser_project():
     """This function demonstrates different loading options of TEASER"""
-
-    # In example e4_save we saved two TEASER projects using `*.teaserjson` and
-    # Python package pickle. This example shows how to import these
-    # information into your python environment again.
-
     prj_export_path, prj_json_path = run_serialize_teaser_project_example()
     prj = Project()
 

--- a/bim2sim/plugins/PluginTEASER/bim2sim_teaser/examples/e6_load_serialized_teaser_prj.py
+++ b/bim2sim/plugins/PluginTEASER/bim2sim_teaser/examples/e6_load_serialized_teaser_prj.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+from teaser.project import Project
+
+from bim2sim_teaser.task import CreateTEASER
+from e5_serialize_teaser_prj import run_serialize_teaser_project_example
+
+
+def example_load():
+    """This function demonstrates different loading options of TEASER"""
+
+    # In example e4_save we saved two TEASER projects using `*.teaserjson` and
+    # Python package pickle. This example shows how to import these
+    # information into your python environment again.
+
+    # To load data from `*.teaserjson` we can use a simple API function. So
+    # first we need to instantiate our API (similar to example
+    # e1_generate_archetype). The json file is called
+    # `ArchetypeExample.teaserjson` and saved in the default path. You need to
+    # run e4 first before you can load this example file.
+    prj_export_path, prj_json_path = run_serialize_teaser_project_example()
+    prj = Project()
+
+    prj.load_project(path=prj_json_path)
+    export_vars = {
+        "HeatingDemands": ["*multizone.PHeater*", "*multizone.PHeatAHU"],
+        "CoolingDemands": ["*multizone.PCooler*", "*multizone.PCoolAHU"],
+        "Temperatures": ["*multizone.TAir*", "*multizone.TRad*"]
+    }
+
+    # Do some work on the model, e.g. increase total window area of each
+    # thermal zone by 10 %
+    window_increase_percentage = 0.1
+    for bldg in prj.buildings:
+        for tz in bldg.thermal_zones:
+            ow_area_old = 0
+            for ow in tz.outer_walls:
+                ow_area_old += ow.area
+            win_area_old = 0
+            for win in tz.windows:
+                win_area_old += win.area
+            win_ratio = win_area_old / ow_area_old
+            print(f"Current window to wall ratio of thermal zone "
+                  f"{tz.name} is {round(win_ratio*100,2 )} %. "
+                  f"Increasing total window "
+                  f"area by {window_increase_percentage*100} %.")
+            # calculate the total new window area
+            win_area_new = (1 + window_increase_percentage) * win_area_old
+            win_area_increase = win_area_new-win_area_old
+            ow_area_new = ow_area_old - win_area_increase
+            ow_area_decrease = ow_area_old - ow_area_new
+            # distribute the changes on the different windows and outer walls
+            # based on their percentage ratio
+            for win in tz.windows:
+                win.area += win_area_increase * win.area/win_area_old
+            for ow in tz.outer_walls:
+                ow.area -= ow_area_decrease * ow.area/ow_area_old
+            # check new areas
+            ow_area_res = 0
+            for ow in tz.outer_walls:
+                ow_area_res += ow.area
+            win_area_res = 0
+            for win in tz.windows:
+                win_area_res += win.area
+            win_ratio_res = win_area_res/ow_area_res
+            print(f"New window to wall ratio of thermal zone "
+                  f"{tz.name} is {round(win_ratio_res*100,2 )} %.")
+    # calculate all buildings, this is needed as model_attr and library_attr
+    # are not saved via json export.
+    prj.calc_all_buildings()
+
+    # As calc_all_buildings() recalculates the heating loads and thus the max
+    # ideal heater PI-control values, we might reset those as they can be too
+    # low and lead to too low zone temperatures
+    orig_heat_loads, orig_cool_loads = CreateTEASER.overwrite_heatloads(
+        prj.buildings)
+
+    prj.export_aixlib(
+        path=prj_export_path,
+        use_postprocessing_calc=True,
+        report=True,
+        export_vars=export_vars
+    )
+
+
+if __name__ == "__main__":
+    example_load()
+
+    print("Example 5: That's it! :)")

--- a/bim2sim/plugins/PluginTEASER/bim2sim_teaser/models/__init__.py
+++ b/bim2sim/plugins/PluginTEASER/bim2sim_teaser/models/__init__.py
@@ -242,6 +242,8 @@ class ElementWithLayers(TEASER):
     def __init__(self, element):
         self.add_layers_to_element(element)
         super().__init__(element)
+        self.name = self.element.guid
+
 
     def add_layers_to_element(self, element):
         if element.layerset:

--- a/bim2sim/plugins/PluginTEASER/bim2sim_teaser/task/__init__.py
+++ b/bim2sim/plugins/PluginTEASER/bim2sim_teaser/task/__init__.py
@@ -3,3 +3,4 @@ from .create_teaser_prj import CreateTEASER
 from .simulate_dymola_ebcpy import SimulateModelEBCPy
 from .create_result_df import CreateResultDF
 from .load_modelica_results import LoadModelicaResults
+from .serialize_teaser_prj import SerializeTEASER

--- a/bim2sim/plugins/PluginTEASER/bim2sim_teaser/task/create_teaser_prj.py
+++ b/bim2sim/plugins/PluginTEASER/bim2sim_teaser/task/create_teaser_prj.py
@@ -68,7 +68,7 @@ class CreateTEASER(ITask):
             instance.collect_params()
 
         self.prepare_export(exported_buildings)
-
+        teaser_prj.calc_all_buildings()
         orig_heat_loads, orig_cool_loads =\
             self.overwrite_heatloads(exported_buildings)
         teaser_prj.weather_file_path = weather_file
@@ -130,6 +130,7 @@ class CreateTEASER(ITask):
         # outer elements or without windows, causes singularity problem
         if len(tz.outer_walls + tz.rooftops) == 0:
             ow_min = OuterWall(parent=tz)
+            ow_min.name = 'min_outer_wall'
             ow_min.area = 0.01
             ow_min.load_type_element(
                 year=bldg.year_of_construction,
@@ -138,13 +139,14 @@ class CreateTEASER(ITask):
             ow_min.tilt = 90
             ow_min.orientation = 0
         if len(tz.windows) == 0:
-            ow_min = Window(parent=tz)
-            ow_min.area = 0.01
-            ow_min.load_type_element(
+            win_min = Window(parent=tz)
+            win_min.name = 'min_window'
+            win_min.area = 0.01
+            win_min.load_type_element(
                 year=bldg.year_of_construction,
                 construction='EnEv',
             )
-            ow_min.orientation = 0
+            win_min.orientation = 0
 
     @staticmethod
     def rotate_teaser_building(bldg: Building, true_north: float):

--- a/bim2sim/plugins/PluginTEASER/bim2sim_teaser/task/serialize_teaser_prj.py
+++ b/bim2sim/plugins/PluginTEASER/bim2sim_teaser/task/serialize_teaser_prj.py
@@ -1,0 +1,27 @@
+from bim2sim.tasks.base import ITask
+
+
+class SerializeTEASER(ITask):
+    """Creates the TEASER project, run() method holds detailed information."""
+    reads = ('teaser_prj',)
+
+    def run(self, teaser_prj):
+        """Serialize the created TEASER project.
+
+        This is useful if we want to work on the created TEASER project outside
+        of bim2sim and don't want to export it directly to Modelica.
+
+        Args:
+            teaser_prj: teaser project instance
+
+        """
+        self.logger.info("Serializing the created TEASER project")
+        self.paths.export.joinpath("TEASER/serialized_teaser").mkdir(parents=True,
+                                                              exist_ok=True)
+        teaser_prj.save_project(
+            file_name=self.prj_name,
+            path=self.paths.export / "TEASER/serialized_teaser")
+
+        self.logger.info(
+            f'Saved TEASER project '
+            f'to {self.paths.export.joinpath("TEASER/serialized_teaser")}')


### PR DESCRIPTION
This adds a new task that can be used to serialize TEASER projects, which can be used to export TEASER projects to .json and import them later on. I also added two examples to show the save and use functionality.

closes #755 