### PR TITLE
Improve top bottom

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "test/resources"]
 	path = test/resources
 	url = https://github.com/BIM2SIM/bim2sim-test-resources.git
+    branch = top_bottom_changes

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "test/resources"]
 	path = test/resources
 	url = https://github.com/BIM2SIM/bim2sim-test-resources.git
-    branch = top_bottom_changes
+    branch = main

--- a/bim2sim/elements/bps_elements.py
+++ b/bim2sim/elements/bps_elements.py
@@ -670,11 +670,11 @@ class SpaceBoundary(RelationBased):
     @cached_property
     def top_bottom(self) -> BoundaryOrientation:
         """
-        Determines if a boundary is a top (ceiling/roof) or bottom (floor/slab) element
-        based solely on its normal vector orientation.
+        Determines if a boundary is a top (ceiling/roof) or bottom (floor/slab)
+         element based solely on its normal vector orientation.
 
-        Classification is based on the dot product between the boundary's normal vector
-        and the vertical vector (0, 0, 1):
+        Classification is based on the dot product between the boundary's
+        normal vector and the vertical vector (0, 0, 1):
         - TOP: when normal points upward (dot product > cos(89°))
         - BOTTOM: when normal points downward (dot product < cos(91°))
         - VERTICAL: when normal is perpendicular to vertical (dot product ≈ 0)
@@ -682,21 +682,21 @@ class SpaceBoundary(RelationBased):
         Returns:
             BoundaryOrientation: Enumerated orientation classification
         """
-        VERTICAL_VECTOR = gp_XYZ(0.0, 0.0, 1.0)
-        VERTICAL_TOLERANCE = 1e-3
-        COS_ANGLE_TOP = math.cos(math.radians(89))
-        COS_ANGLE_BOTTOM = math.cos(math.radians(91))
+        vertical_vector = gp_XYZ(0.0, 0.0, 1.0)
+        vertical_tolerance = 1e-3
+        cos_angle_top = math.cos(math.radians(89))
+        cos_angle_bottom = math.cos(math.radians(91))
 
-        normal_dot_vertical = VERTICAL_VECTOR.Dot(self.bound_normal)
+        normal_dot_vertical = vertical_vector.Dot(self.bound_normal)
 
         # Check if boundary is vertical
-        if abs(normal_dot_vertical) < VERTICAL_TOLERANCE:
+        if abs(normal_dot_vertical) < vertical_tolerance:
             return BoundaryOrientation.vertical
 
         # Classify based on dot product
-        if normal_dot_vertical > COS_ANGLE_TOP:
+        if normal_dot_vertical > cos_angle_top:
             return BoundaryOrientation.top
-        elif normal_dot_vertical < COS_ANGLE_BOTTOM:
+        elif normal_dot_vertical < cos_angle_bottom:
             return BoundaryOrientation.bottom
 
         return BoundaryOrientation.vertical

--- a/bim2sim/elements/bps_elements.py
+++ b/bim2sim/elements/bps_elements.py
@@ -683,15 +683,10 @@ class SpaceBoundary(RelationBased):
             BoundaryOrientation: Enumerated orientation classification
         """
         vertical_vector = gp_XYZ(0.0, 0.0, 1.0)
-        vertical_tolerance = 1e-3
         cos_angle_top = math.cos(math.radians(89))
         cos_angle_bottom = math.cos(math.radians(91))
 
         normal_dot_vertical = vertical_vector.Dot(self.bound_normal)
-
-        # Check if boundary is vertical
-        if abs(normal_dot_vertical) < vertical_tolerance:
-            return BoundaryOrientation.vertical
 
         # Classify based on dot product
         if normal_dot_vertical > cos_angle_top:

--- a/bim2sim/elements/bps_elements.py
+++ b/bim2sim/elements/bps_elements.py
@@ -587,20 +587,20 @@ class SpaceBoundary(RelationBased):
         self.bound_thermal_zone = None
         self._elements = elements
 
-    def calc_orientation(self):
-        """
-        calculates the orientation of the spaceboundary, using the relative
-        position of resultant disaggregation
-        """
-        if hasattr(self.ifc.ConnectionGeometry.SurfaceOnRelatingElement,
-                   'BasisSurface'):
-            axis = self.ifc.ConnectionGeometry.SurfaceOnRelatingElement. \
-                BasisSurface.Position.Axis.DirectionRatios
-        else:
-            axis = self.ifc.ConnectionGeometry.SurfaceOnRelatingElement. \
-                Position.Axis.DirectionRatios
-
-        return vector_angle(axis)
+    # def calc_orientation(self):
+    #     """
+    #     calculates the orientation of the spaceboundary, using the relative
+    #     position of resultant disaggregation
+    #     """
+    #     if hasattr(self.ifc.ConnectionGeometry.SurfaceOnRelatingElement,
+    #                'BasisSurface'):
+    #         axis = self.ifc.ConnectionGeometry.SurfaceOnRelatingElement. \
+    #             BasisSurface.Position.Axis.DirectionRatios
+    #     else:
+    #         axis = self.ifc.ConnectionGeometry.SurfaceOnRelatingElement. \
+    #             Position.Axis.DirectionRatios
+    #
+    #     return vector_angle(axis)
 
     def calc_position(self):
         """
@@ -709,16 +709,23 @@ class SpaceBoundary(RelationBased):
         # TODO: This might fail for multi storey spaces.
         else:
             if (self.bound_center.Z() - self.bound_thermal_zone.space_center.Z()) \
-                    > 1e-2:
+                    > 1e-8:
                 top_bottom = "TOP"
             elif (self.bound_center.Z() - self.bound_thermal_zone.space_center.Z()) \
-                    < -1e-2:
+                    < -1e-8:
                 top_bottom = "BOTTOM"
             else:
+                # maximum angle between vertical vector (0,0,1) and normal
+                #  80 is a very steep roof
+                angle_threshold_top = 89
+                angle_threshold_bottom = 91
                 # caution, this relies on correct surface normals
-                if vertical.Dot(self.bound_normal) < -0.8:
+                if vertical.Dot(self.bound_normal) < math.cos(
+                        math.radians(angle_threshold_bottom)):
                     top_bottom = "BOTTOM"
-                elif vertical.Dot(self.bound_normal) > 0.8:
+                # 0.985 is equal to a 10 degree angle between
+                elif vertical.Dot(self.bound_normal) > math.cos(
+                        math.radians(angle_threshold_top)):
                     top_bottom = "TOP"
         return top_bottom
 

--- a/bim2sim/plugins/PluginEnergyPlus/bim2sim_energyplus/task/ep_create_idf.py
+++ b/bim2sim/plugins/PluginEnergyPlus/bim2sim_energyplus/task/ep_create_idf.py
@@ -29,6 +29,7 @@ from bim2sim.tasks.base import ITask
 from bim2sim.utilities.common_functions import filter_elements, \
     get_spaces_with_bounds, all_subclasses
 from bim2sim.utilities.pyocc_tools import PyOCCTools
+from bim2sim.utilities.types import BoundaryOrientation
 
 if TYPE_CHECKING:
     from bim2sim.plugins.PluginEnergyPlus.bim2sim_energyplus import \
@@ -1757,11 +1758,11 @@ class IdfObject:
                     surface_type = "Floor"
                 elif any([isinstance(elem, floor) for floor in all_subclasses(
                         InnerFloor, include_self=True)]):
-                    if inst_obj.top_bottom == "BOTTOM":
+                    if inst_obj.top_bottom == BoundaryOrientation.bottom:
                         surface_type = "Floor"
-                    elif inst_obj.top_bottom == "TOP":
+                    elif inst_obj.top_bottom == BoundaryOrientation.top:
                         surface_type = "Ceiling"
-                    elif inst_obj.top_bottom == "VERTICAL":
+                    elif inst_obj.top_bottom == BoundaryOrientation.vertical:
                         surface_type = "Wall"
                         logger.warning(f"InnerFloor with vertical orientation "
                                        f"found, exported as wall, "
@@ -1780,21 +1781,21 @@ class IdfObject:
             #             surface_type = 'Ceiling'
             #     elif elem.ifc.is_a('IfcColumn'):
             #         surface_type = 'Wall'
-            elif inst_obj.top_bottom == "BOTTOM":
+            elif inst_obj.top_bottom == BoundaryOrientation.bottom:
                 surface_type = "Floor"
-            elif inst_obj.top_bottom == "TOP":
+            elif inst_obj.top_bottom == BoundaryOrientation.top:
                 surface_type = "Ceiling"
                 if inst_obj.related_bound is None or inst_obj.is_external:
                     surface_type = "Roof"
-            elif inst_obj.top_bottom == "VERTICAL":
+            elif inst_obj.top_bottom == BoundaryOrientation.vertical:
                 surface_type = "Wall"
             else:
                 if not PyOCCTools.compare_direction_of_normals(
                         inst_obj.bound_normal, gp_XYZ(0, 0, 1)):
                     surface_type = 'Wall'
-                elif inst_obj.top_bottom == "BOTTOM":
+                elif inst_obj.top_bottom == BoundaryOrientation.bottom:
                     surface_type = "Floor"
-                elif inst_obj.top_bottom == "TOP":
+                elif inst_obj.top_bottom == BoundaryOrientation.top:
                     surface_type = "Ceiling"
                     if inst_obj.related_bound is None or inst_obj.is_external:
                         surface_type = "Roof"
@@ -1805,9 +1806,9 @@ class IdfObject:
                     inst_obj.bound_normal, gp_XYZ(0, 0, 1)):
                 surface_type = 'Wall'
             else:
-                if inst_obj.top_bottom == "BOTTOM":
+                if inst_obj.top_bottom == BoundaryOrientation.bottom:
                     surface_type = "Floor"
-                elif inst_obj.top_bottom == "TOP":
+                elif inst_obj.top_bottom == BoundaryOrientation.top:
                     surface_type = "Ceiling"
         else:
             logger.warning(f"No surface type matched for {inst_obj}!")

--- a/bim2sim/plugins/PluginTEASER/bim2sim_teaser/export/__init__.py
+++ b/bim2sim/plugins/PluginTEASER/bim2sim_teaser/export/__init__.py
@@ -13,6 +13,7 @@ from bim2sim.elements.aggregation.bps_aggregations import AggregatedThermalZone
 from bim2sim.kernel import log
 from bim2sim.elements.base_elements import Element
 from bim2sim.elements.base_elements import Dummy as ElementDummy
+from bim2sim.utilities.types import BoundaryOrientation
 
 lock = Lock()
 
@@ -179,12 +180,12 @@ class TEASERExportInstance:
         else:
             sb_ele = sbs_ele_inside_zone[0]
             top_bottom = sb_ele.top_bottom
-            if top_bottom == 'TOP':
+            if top_bottom == BoundaryOrientation.top:
                 export_cls = Ceiling
-            elif top_bottom == 'BOTTOM':
+            elif top_bottom == BoundaryOrientation.bottom:
                 export_cls = Floor
             # This might be the case of slabs with opening inside a IfcSpace
-            elif top_bottom == 'VERTICAL':
+            elif top_bottom == BoundaryOrientation.vertical:
                 export_cls = Ceiling
             else:
                 logger.error(

--- a/bim2sim/tasks/bps/disaggr_creation.py
+++ b/bim2sim/tasks/bps/disaggr_creation.py
@@ -12,6 +12,8 @@ from bim2sim.elements.bps_elements import (
 from bim2sim.elements.mapping.units import ureg
 from bim2sim.tasks.base import ITask
 from bim2sim.utilities.common_functions import all_subclasses
+from bim2sim.utilities.types import BoundaryOrientation
+
 if TYPE_CHECKING:
     from bim2sim.elements.bps_elements import SpaceBoundary
 
@@ -339,16 +341,16 @@ class DisaggregationCreationAndTypeCheck(ITask):
                 if sb.is_external:
                     if sb.internal_external_type == 'EXTERNAL_EARTH':
                         return GroundFloor
-                    elif sb.top_bottom == 'BOTTOM':
+                    elif sb.top_bottom == BoundaryOrientation.bottom:
                         # Possible failure for overhangs that are external but
                         # have contact to air, because IFC provides
                         # information about "EXTERNAL_EARTH" only in rare cases
                         return GroundFloor
-                    elif sb.top_bottom == 'TOP':
+                    elif sb.top_bottom == BoundaryOrientation.top:
                         return Roof
                     # vertical slabs might occur in IFC but will be mapped to
                     # bim2sim OuterWall
-                    elif sb.top_bottom == "VERTICAL":
+                    elif sb.top_bottom == BoundaryOrientation.vertical:
                         return OuterWall
                     else:
                         self.logger.error(f"Error in type correction of "

--- a/bim2sim/utilities/types.py
+++ b/bim2sim/utilities/types.py
@@ -65,3 +65,16 @@ class AttributeDataSource(Enum):
     manual_overwrite = auto()
     enrichment = auto()
     space_boundary = auto()
+
+
+class BoundaryOrientation(Enum):
+    """
+    Enumeration for boundary orientations.
+
+    top: Ceilings, roofs (normal points upward)
+    bottom: Floors, slabs (normal points downward)
+    vertical: Walls (normal perpendicular to vertical)
+    """
+    top = auto()
+    bottom = auto()
+    vertical = auto()

--- a/docs/source/developer-guide/testing.md
+++ b/docs/source/developer-guide/testing.md
@@ -56,10 +56,11 @@ If test resources needs to be updated, please follow the following procedure:
 #### [Main bim2sim Repository](https://github.com/BIM2SIM/bim2sim)
 4. Create a branch called `update_resources_submodule` from the current `development` branch
 5. Checkout this branch on your local device and perform the following commands in the root path:
-   1. `cd test/resources` (Go into the submodule directory)
-   2. `git pull origin update_test_resources` (Pull the latest changes of the test resources submodule)
-   3. `cd ../..` (Go back to parent repo)
-   4. `git add test/resources` (add the changes)
+   1. open the .gitmodules file in the room of bim2sim and adjust the branch to the test-resources branch (in this case `update_test_resources`)
+   2. run `git submodule update --init --recursive --remote` in bim2sim root directory (update submodule)
+   3. `cd /test/resources` and run `git checkout update_test_resources` (checkout the branch)
+   4. `cd ../..` (Go back to parent repo)
+   4. `git add .` (add the changes)
    5. `git commit -m "Update submodule of test resources"`
    6. `git push`
 6. Wait for the pipeline to run through on your branch, this makes sure that the code runs with the new test resources without issues

--- a/docs/source/developer-guide/testing.md
+++ b/docs/source/developer-guide/testing.md
@@ -58,7 +58,7 @@ If test resources needs to be updated, please follow the following procedure:
 5. Checkout this branch on your local device and perform the following commands in the root path:
    1. open the .gitmodules file in the room of bim2sim and adjust the branch to the new test-resources branch (in this case `update_test_resources`)
    2. in bim2sim root directory run `git submodule sync` and afterwards `git submodule update --recursive --remote` (update submodule according to changes in .gitmodules file)
-   3. `git add .` (add the changes)
+   3. `git add .\test\resources .gitmodules` (add the changes)
    4. `git commit -m "Update submodule of test resources"`
    5. `git push`
 6. Wait for the pipeline to run through on your branch, this makes sure that the code runs with the new test resources without issues

--- a/docs/source/developer-guide/testing.md
+++ b/docs/source/developer-guide/testing.md
@@ -56,13 +56,11 @@ If test resources needs to be updated, please follow the following procedure:
 #### [Main bim2sim Repository](https://github.com/BIM2SIM/bim2sim)
 4. Create a branch called `update_resources_submodule` from the current `development` branch
 5. Checkout this branch on your local device and perform the following commands in the root path:
-   1. open the .gitmodules file in the room of bim2sim and adjust the branch to the test-resources branch (in this case `update_test_resources`)
-   2. run `git submodule update --init --recursive --remote` in bim2sim root directory (update submodule)
-   3. `cd /test/resources` and run `git checkout update_test_resources` (checkout the branch)
-   4. `cd ../..` (Go back to parent repo)
-   4. `git add .` (add the changes)
-   5. `git commit -m "Update submodule of test resources"`
-   6. `git push`
+   1. open the .gitmodules file in the room of bim2sim and adjust the branch to the new test-resources branch (in this case `update_test_resources`)
+   2. in bim2sim root directory run `git submodule sync` and afterwards `git submodule update --recursive --remote` (update submodule according to changes in .gitmodules file)
+   3. `git add .` (add the changes)
+   4. `git commit -m "Update submodule of test resources"`
+   5. `git push`
 6. Wait for the pipeline to run through on your branch, this makes sure that the code runs with the new test resources without issues
 7. If the pipeline with all tests passes, perform the following steps, otherwise fix the issues before you continue
 #### [Test Resources Repository](https://github.com/BIM2SIM/bim2sim-test-resources)
@@ -70,7 +68,7 @@ If test resources needs to be updated, please follow the following procedure:
 9. Link the succeeded pipeline in this PR and assign a reviewer
 10. When review finished, merge the PR
 #### [Main bim2sim Repository](https://github.com/BIM2SIM/bim2sim)
-11. Repeat the same steps as under step 6, but this time in step 6.ii use `main` instead `update_test_resources` as branch name
+11. Repeat the same steps as under step 6, but this time in step 5.1 use `main` instead `update_test_resources` as branch name
 12. again wait for the pipeline to succeed
 13. Create a PR to merge `update_resources_submodule` branch in the `main` branch and assign a reviewer
 14. If pipeline has passed (what it should) and review is approved merge the PR


### PR DESCRIPTION
* introduce enums for boundary orientation (top, bottom, vertical)
* improve top_bottom algorithm readability and set maximum and minimum angles of `alpha`to 89 ° and 91 ° (see image) because for tilted roofs the algorithm was not working
* only use normal vector from now on to determine the boundary orientation
* remove unused `calc_orientation` function for space boundaries

This fixes some previous errors with assignment of floors as roofs and vice versa

![image](https://github.com/user-attachments/assets/ed34b34e-cbf4-4856-a7b4-28ac8d3df29a)

