### PR TITLE
add reset functionality for attribute and tests

### DIFF
--- a/bim2sim/elements/base_elements.py
+++ b/bim2sim/elements/base_elements.py
@@ -18,7 +18,7 @@ from bim2sim.elements.mapping.units import ureg
 from bim2sim.utilities.common_functions import angle_equivalent, vector_angle, \
     remove_umlaut
 from bim2sim.utilities.pyocc_tools import PyOCCTools
-from bim2sim.utilities.types import IFCDomain
+from bim2sim.utilities.types import IFCDomain, AttributeDataSource
 
 logger = logging.getLogger(__name__)
 quality_logger = logging.getLogger('bim2sim.QualityReport')
@@ -118,6 +118,14 @@ class Element(metaclass=attribute.AutoAttributeNameMeta):
             external_decision: Decision to use instead of default decision
         """
         return self.attributes.request(name, external_decision)
+
+    def reset(self, name, data_source=AttributeDataSource.manual_overwrite):
+        """Reset the attribute of the element.
+        Args:
+            name: attribute name
+            data_source (object): data source of the attribute
+        """
+        return self.attributes.reset(name, data_source)
 
     def source_info(self) -> str:
         """Get informative string about source of Element."""

--- a/bim2sim/elements/mapping/attribute.py
+++ b/bim2sim/elements/mapping/attribute.py
@@ -38,6 +38,7 @@ class Attribute:
         REQUESTED: Attribute was already requested via a decision??.
         AVAILABLE: Attribute exists and is available.
         NOT_AVAILABLE: No way was found to obtain the attributes value.
+        RESET: The Attribute was reset.
 
     To find more about Descriptor objects follow the explanations on
     https://rszalski.github.io/magicmethods/#descriptor
@@ -46,6 +47,7 @@ class Attribute:
     STATUS_REQUESTED = 'REQUESTED'
     STATUS_AVAILABLE = 'AVAILABLE'
     STATUS_NOT_AVAILABLE = 'NOT_AVAILABLE'
+    STATUS_RESET = 'RESET'
 
     def __init__(self,
                  description: str = "",
@@ -344,6 +346,11 @@ class Attribute:
         # Case 4: Value is available or already requested (no action needed)
         return
 
+    def reset(self, bind, data_source=AttributeDataSource.manual_overwrite):
+        """Reset attribute, set to None and STATUS_NOT_AVAILABLE."""
+        self._inner_set(
+            bind, None, Attribute.STATUS_RESET, data_source)
+
     def get_dependency_decisions(self, bind, external_decision=None):
         """Get dependency decisions"""
         status = Attribute.STATUS_REQUESTED
@@ -488,7 +495,8 @@ class Attribute:
         else:
             value = value_or_decision
 
-        if value is None and status == self.STATUS_UNKNOWN:
+        if (value is None and status
+                in [self.STATUS_UNKNOWN, self.STATUS_RESET]):
             value, data_source = self._get_value(bind)
             status = self.STATUS_AVAILABLE if value is not None \
                 else self.STATUS_NOT_AVAILABLE  # change for temperature
@@ -576,6 +584,14 @@ class AttributeManager(dict):
         for k, v in other.items():
             self.__setitem__(k, v)
 
+    def reset(self, name, data_source=AttributeDataSource.manual_overwrite):
+        """Reset attribute, set to None and STATUS_NOT_AVAILABLE."""
+        try:
+            attr = self.get_attribute(name)
+        except KeyError:
+            raise KeyError("%s has no Attribute '%s'" % (self.bind, name))
+        attr.reset(self.bind, data_source)
+
     def request(self, name: str, external_decision: Decision = None) \
             -> Union[None, Decision]:
         """Request attribute by name.
@@ -594,7 +610,7 @@ class AttributeManager(dict):
         except KeyError:
             raise KeyError("%s has no Attribute '%s'" % (self.bind, name))
         value, status, data_source = self[name]
-        if status == Attribute.STATUS_UNKNOWN:
+        if status in [Attribute.STATUS_UNKNOWN, Attribute.STATUS_RESET]:
             # make sure default methods are tried
             getattr(self.bind, name)
             value, status, data_source = self[name]


### PR DESCRIPTION
closes #760

description copied from issue:
For attributes, for which a `__get__` via element.attribute (e.g.  tz.lighting_power`)  has been performed before and thus are already calculated, the status will be `STATUS_AVAILABLE`. Those attributes won't be recalculated again if the `__get__` method is called again. This behaviour is on purpose and totally fine, but in some cases (e.g. enrichment) we want to reset those attributes, to make sure that the enrichment works properly.

Therefore we need a reset option for attributes.


