### PR TITLE
allow None as valid value for BooleanSettings

### DIFF
--- a/bim2sim/sim_settings.py
+++ b/bim2sim/sim_settings.py
@@ -355,8 +355,9 @@ class PathSetting(Setting):
 
 class BooleanSetting(Setting):
     def check_value(self, bound_simulation_settings, value):
-        if not isinstance(value, bool):
-            raise ValueError(f"The provided value {value} is not a Boolean")
+        if not isinstance(value, bool) and value is not None:
+            raise ValueError(f"The provided value {value} for sim_setting "
+                             f"{self.name} is not a Boolean")
         else:
             return True
 


### PR DESCRIPTION
For some `BooleanSettings` we want to use `None` as default. E.g. an setting like 
`ahu_dehumidification_overwrite` can be set to `True` to always use Dehumidification or `False` to never use Dehumidification but in case we don't want to overwrite it we will leave the default to `None`. 

Currently examples, where the settings `ahu_dehumidification_overwrite`, `ahu_cooling_overwrite` or `ahu_heating_overwrite` (which use `None` as default) have no value set will fail, as only `True` and `False` are accepted for `BooleanSetting` values.