### PR TITLE
set Coverage to false (like for py310)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -151,7 +151,7 @@ py3.11:
   image: $CI_REGISTRY/bim2sim:py3.11-occ7.9.0
   variables:
     PYTHON_VERSION: "3.11"
-    COVERAGE: "true"
+    COVERAGE: "false"
 
 # Integration tests
 PluginTEASER:py3.10:

--- a/docs/source/user-guide/PluginTemplate.md
+++ b/docs/source/user-guide/PluginTemplate.md
@@ -37,6 +37,13 @@ We will guide you through the process now.
 ```shell
 # create fresh python environment with conda (python 3.10 to 3.11 are supported currently)
 micromamba create -n bim2sim python=3.11 -c conda-forge
+
+# optional (instead of step before), when use coverage as part of testing
+# by installing pip -e '.[test]'
+# env.yml includes specifications for the environment (here pin setuptools to 80.9.0)
+micromamba create -n bim2sim -f env.yml
+
+
 # activate your environment
 micromamba activate bim2sim
 

--- a/env.yml
+++ b/env.yml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+dependencies:
+  - python >=3.10, <3.12
+  - setuptools==80.9.0


### PR DESCRIPTION
to switch off coverage is needed because coverage try to load pkg_resources, but with setuptools > 80.9. 
pkg_resources is deprecated

from coverage_badge.__main__ import main
/lib/python3.11/site-packages/coverage_badge/__main__.py:7: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
