### PR TITLE
pin/downgrade setuptools (because coverage-badge)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,8 +144,10 @@ docu = [
     "tabulate",
 ]
 test = [
-    "coverage", # [toml] not needed using micromanba, maybe also new python version
+    "coverage",
     "coverage-badge",
+    "setuptools==80.9.0" # downgrade setuptools, because of coverage-badge
+    # see https://github.com/dbrgn/coverage-badge/issues/33
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
lib/python3.11/site-packages/coverage_badge/__main__.py:7: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
