### PR TITLE
Fix case-sensitive section-name match in sim settings loader

### DIFF
--- a/bim2sim/sim_settings.py
+++ b/bim2sim/sim_settings.py
@@ -276,7 +276,7 @@ class BaseSimSettings(metaclass=AutoSettingNameMeta):
             # don't load settings which are not simulation relevant
             if cat.lower() not in [
                 self.__class__.__name__.lower(),
-                'Generic Simulation Settings'
+                'generic simulation settings'
             ]:
                 continue
             cat_from_cfg = config[cat]


### PR DESCRIPTION
`BaseSimSettings.update_from_config` lowercases the section name from the config file but compares it against a list that contains the literal 'Generic Simulation Settings'. As a result, settings under the [Generic Simulation Settings] section were silently skipped, and mandatory settings declared there (e.g. weather_file_path) were never populated — triggering a misleading "not specified" error at run time.

Lowercase the literal so the comparison is case-insensitive on both sides.